### PR TITLE
Add generated Python protobuf stub files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,5 +87,10 @@ MODULE.bazel.lock
 /jax/
 /xla/
 
+# Generated Python protobuf modules copied by build.sh
+/tpu_raiden/rpc/raiden_service_pb2.py
+/tpu_raiden/rpc/coordination_pb2.py
+/tpu_raiden/rpc/coordination_pb2_grpc.py
+
 # Python bytecode caches
 **/__pycache__/


### PR DESCRIPTION
- tpu_raiden/rpc/raiden_service_pb2.py
- tpu_raiden/rpc/coordination_pb2.py
- tpu_raiden/rpc/coordination_pb2_grpc.py
These 3 files are Bazel generated from the .proto files via py_proto_library / py_grpc_library targets in tpu-raiden/tpu_raiden/rpc/BUILD:29. Adding to .gitignore.