### PR TITLE
build: bump abseil-cpp to 20260526.0 for torch_tpu compatibility

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -78,7 +78,18 @@ use_repo(
     "stablehlo",
 )
 
-bazel_dep(name = "abseil-cpp", version = "20260107.1", repo_name = "com_google_absl")
+bazel_dep(name = "abseil-cpp", version = "20260526.0", repo_name = "com_google_absl")
+
+# abseil-cpp 20260526.0 (required by torch_tpu) is declared incompatible with
+# all previous releases: its module metadata dropped `compatibility_level = 1`,
+# and bzlmod refuses to mix compatibility levels. Force all dependencies onto
+# this version until an abseil release restores the compatibility level
+# (https://github.com/abseil/abseil-cpp/pull/2063 dropped it without
+# explanation), after which the plain bazel_dep above suffices.
+single_version_override(
+    module_name = "abseil-cpp",
+    version = "20260526.0",
+)
 
 # OSS crypto for global_registry_client.cc SHA256.
 bazel_dep(name = "boringssl", version = "0.20240913.0")


### PR DESCRIPTION
Fixes the module-resolution failure reported when building raiden's torch extension against a current torch_tpu checkout (e.g. in vLLM setups):

```
ERROR: Error computing the main repository mapping: torch_tpu@_ depends on abseil-cpp@20260526.0 with compatibility level 0, but <root> depends on abseil-cpp@20260107.1 with compatibility level 1 which is different
```

torch_tpu moved to abseil-cpp 20260526.0 as part of its XLA revision bump. That BCR entry has no `compatibility_level` (defaults to 0) while older abseil releases are level 1, and bzlmod refuses to unify across levels — so the version bump alone is not enough; the added `single_version_override` is what forces selection past the mismatch (transitive deps such as protobuf 33.5 still request level-1 releases).

Validated in the ml-build container:
- torch wheel builds against torch_tpu main HEAD (a7191cab), which previously failed as above
- jax wheel builds unchanged
- raiden's pinned XLA (5a9e73cb) compiles against the new abseil; no XLA bump needed

Note: after this lands, building against torch_tpu checkouts older than its abseil bump (e20c0244) fails with the mirror-image error — keep torch_tpu checkouts current.