### PR TITLE
Move bap runner to linux-x86-n2-8

### DIFF
--- a/.github/workflows/run_benchmarks.yml
+++ b/.github/workflows/run_benchmarks.yml
@@ -36,7 +36,7 @@ jobs:
     with:
       registry_file: "tpu_raiden/benchmarks/benchmark_registry.pbtxt"
       ml_actions_ref: "affd28b492f67c242afa8b119e590b25816b7b88"
-      runner: "linux-x86-n2-32"
+      runner: "linux-x86-n2-8"
       publish_metrics: false
       pub_sub_gcp_project_id: "ml-oss-benchmarking-production"
       pub_sub_gcp_topic_id: "public-results-prod"


### PR DESCRIPTION
n2-32 was causing 1 hour+ hangups. Moving to n2-8 with increased runners / idle hosts.