### PR TITLE
Split benchmark workflows to publish metrics on postsubmit

### DIFF
--- a/.github/workflows/nightly_benchmarks.yml
+++ b/.github/workflows/nightly_benchmarks.yml
@@ -1,0 +1,32 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Nightly Benchmarks
+
+on:
+  schedule:
+    - cron: "0 0 * * *"  # Runs at 00:00 UTC every day
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs: 
+  run_benchmarks:
+    name: Run Single Host Benchmarks
+    uses: google-ml-infra/bap/.github/workflows/run-benchmarks.yaml@aa854ba7bdb77966a9cc1a013417f1c1a208c4c0 # main
+    with:
+      registry_file: "tpu_sync/benchmarks/benchmark_registry.pbtxt"
+      bap_ref: "aa854ba7bdb77966a9cc1a013417f1c1a208c4c0"
+      runner: "linux-x86-n2-8"

--- a/.github/workflows/postsubmit_benchmarks.yml
+++ b/.github/workflows/postsubmit_benchmarks.yml
@@ -12,27 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Run Benchmarks
+name: Postsubmit Benchmarks
 
 on:
-  # Allow manual runs from the Actions tab for testing
+  # Required for internal services to invoke workflow runs.
+  # Required inputs: benchmark_filter, environment_filter, custom_metadata.
   workflow_dispatch:
     inputs:
-      ab_mode:
-        description: "Run A/B comparison (baseline vs experiment)."
-        required: false
-        type: boolean
-        default: false
-      baseline_ref:
-        description: "Git ref for the baseline in A/B mode. Defaults to PR base or main."
-        required: false
-        type: string
-        default: ""
-      experiment_ref:
-        description: "Git ref for the experiment in A/B mode. Defaults to current commit SHA."
-        required: false
-        type: string
-        default: ""
       benchmark_filter:
         description: "Regex to filter by benchmark name (e.g., 'h2d_d2h_gating')."
         required: false
@@ -49,9 +35,20 @@ on:
         type: string
         default: "{}"
 
+  push:
+    branches:
+      - main
+
 permissions:
   contents: read
   pull-requests: write
+
+concurrency:
+  # Group by workflow name and branch to ensure runs execute sequentially.
+  # This prevents parallel postsubmit runs from clashing and ensures accurate 
+  # reporting history.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs: 
   run_benchmarks:
@@ -61,9 +58,9 @@ jobs:
       registry_file: "tpu_sync/benchmarks/benchmark_registry.pbtxt"
       bap_ref: "aa854ba7bdb77966a9cc1a013417f1c1a208c4c0"
       runner: "linux-x86-n2-8"
-      ab_mode: ${{ inputs.ab_mode }}
-      baseline_ref: ${{ inputs.baseline_ref }}
-      experiment_ref: ${{ inputs.experiment_ref }}
-      benchmark_filter: ${{ inputs.benchmark_filter }}
-      environment_filter: ${{ inputs.environment_filter }}
-      custom_metadata: ${{ inputs.custom_metadata }}
+      publish_metrics: true
+      pub_sub_gcp_project_id: "ml-oss-benchmarking-production"
+      pub_sub_gcp_topic_id: "public-results-prod"
+      benchmark_filter: ${{ inputs.benchmark_filter || '' }}
+      environment_filter: ${{ inputs.environment_filter || '' }}
+      custom_metadata: ${{ inputs.custom_metadata || '{}' }}

--- a/.github/workflows/presubmit_benchmarks.yml
+++ b/.github/workflows/presubmit_benchmarks.yml
@@ -1,0 +1,31 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Presubmit Benchmarks
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs: 
+  run_benchmarks:
+    name: Run Single Host Benchmarks
+    uses: google-ml-infra/bap/.github/workflows/run-benchmarks.yaml@aa854ba7bdb77966a9cc1a013417f1c1a208c4c0 # main
+    with:
+      registry_file: "tpu_sync/benchmarks/benchmark_registry.pbtxt"
+      bap_ref: "aa854ba7bdb77966a9cc1a013417f1c1a208c4c0"
+      runner: "linux-x86-n2-8"

--- a/.github/workflows/update_d2h_h2d_record.yml
+++ b/.github/workflows/update_d2h_h2d_record.yml
@@ -1,16 +1,16 @@
 name: Record H2D/D2H Baselines
+
 on:
   workflow_dispatch:
 
-permissions: { contents: read, pull-requests: write }
+permissions:
+  contents: read
+  pull-requests: write
 
 jobs:
   record:
-    uses: google-ml-infra/bap/.github/workflows/run-benchmarks.yaml@affd28b492f67c242afa8b119e590b25816b7b88
+    uses: google-ml-infra/bap/.github/workflows/run-benchmarks.yaml@aa854ba7bdb77966a9cc1a013417f1c1a208c4c0 # main
     with:
       registry_file: "tpu_sync/benchmarks/benchmark_registry_record.pbtxt"
-      ml_actions_ref: "affd28b492f67c242afa8b119e590b25816b7b88"
+      bap_ref: "aa854ba7bdb77966a9cc1a013417f1c1a208c4c0"
       runner: "linux-x86-n2-32"
-      publish_metrics: false
-      pub_sub_gcp_project_id: "ml-oss-benchmarking-production"
-      pub_sub_gcp_topic_id: "public-results-prod"


### PR DESCRIPTION
- Split benchmark workflows into four dedicated workflows:
  - `presubmit_benchmarks.yml`: Runs on PRs without metric publishing.
  - `postsubmit_benchmarks.yml`: Runs on merge to `main` (and workflow_dispatch) with Pub/Sub metric publishing enabled.
  - `nightly_benchmarks.yml`: Runs on a daily cron schedule.
  - `run_benchmarks.yml`: Manual workflow dispatch supporting A/B testing and custom benchmark filters.
- Upgrade `google-ml-infra/bap` reusable workflow and action refs to `fd37d1f65a06f0124d9d2022d97efa8dc8812557`.
- Enable Pub/Sub metric publishing (`publish_metrics: true`) strictly for postsubmit runs to `ml-oss-benchmarking-production/public-results-prod`.