### PR TITLE
ci: point benchmark registry_file at tpu_sync/ after directory migration

### DIFF
--- a/.github/workflows/run_benchmarks.yml
+++ b/.github/workflows/run_benchmarks.yml
@@ -34,7 +34,7 @@ jobs:
     name: Run Single Host Benchmarks
     uses: google-ml-infra/bap/.github/workflows/run-benchmarks.yaml@affd28b492f67c242afa8b119e590b25816b7b88
     with:
-      registry_file: "tpu_raiden/benchmarks/benchmark_registry.pbtxt"
+      registry_file: "tpu_sync/benchmarks/benchmark_registry.pbtxt"
       ml_actions_ref: "affd28b492f67c242afa8b119e590b25816b7b88"
       runner: "linux-x86-n2-8"
       publish_metrics: false

--- a/.github/workflows/update_d2h_h2d_record.yml
+++ b/.github/workflows/update_d2h_h2d_record.yml
@@ -8,7 +8,7 @@ jobs:
   record:
     uses: google-ml-infra/bap/.github/workflows/run-benchmarks.yaml@affd28b492f67c242afa8b119e590b25816b7b88
     with:
-      registry_file: "tpu_raiden/benchmarks/benchmark_registry_record.pbtxt"
+      registry_file: "tpu_sync/benchmarks/benchmark_registry_record.pbtxt"
       ml_actions_ref: "affd28b492f67c242afa8b119e590b25816b7b88"
       runner: "linux-x86-n2-32"
       publish_metrics: false


### PR DESCRIPTION
## Problem

`Run Benchmarks` has been failing on every `main` commit since 4e8ef56 ("Migrate third_party/tpu_raiden/tpu_raiden/benchmarks to third_party/tpu_raiden/tpu_sync/benchmarks").

That commit moved the benchmarks directory, but the two BAP workflows still pass the pre-migration path as `registry_file`. The reusable workflow resolves it against the repo checkout root, so the `Validate Registry Security` job fails before any benchmark is scheduled:

```
Error: Registry file not found:
/__w/tpu-sync/tpu-sync/user_repo/tpu_raiden/benchmarks/benchmark_registry.pbtxt
```

Timeline:

| | |
|---|---|
| Last successful `Run Benchmarks` on main | `675d06f5`, 2026-08-10T17:19:34Z |
| Migration commit | `4e8ef56`, 2026-08-13 |
| First failing run | `4e8ef56d`, 2026-08-13T22:59:54Z |
| Since then | every main-branch run has failed |

## Fix

Update `registry_file` in both workflows to the migrated paths:

- `.github/workflows/run_benchmarks.yml` → `tpu_sync/benchmarks/benchmark_registry.pbtxt`
- `.github/workflows/update_d2h_h2d_record.yml` → `tpu_sync/benchmarks/benchmark_registry_record.pbtxt`

Both files exist at those paths on `main`, and the registries themselves already reference the migrated Bazel targets (`//tpu_sync/benchmarks:h2d_d2h_benchmark_gating`, `//tpu_sync/benchmarks:h2h_cpp_gate`), so no change is needed inside them.

## Scope / what I could not verify

This clears the `Validate Registry Security` gate, which is where the run currently dies. I could not verify the downstream benchmark jobs end-to-end — those need the TPU runners (`linux-x86-ct5lp-224-8tpu`), which I don't expect to be provisioned for a fork PR. If anything further is stale post-migration, it would surface after this gate rather than being hidden behind it.

## Note on #622

[#622](https://github.com/google/tpu-sync/pull/622) ("Split benchmark workflows to publish metrics on postsubmit") carries the old `tpu_raiden/benchmarks/...` path into three new workflow files (`presubmit_benchmarks.yml`, `postsubmit_benchmarks.yml`, `nightly_benchmarks.yml`). Whichever of these lands second will need the same path update — flagging so it isn't reintroduced.
