### PR TITLE
examples: fix stale bazel label in RAW_TRANSFER.md

### DIFF
--- a/examples/microbenchmarks/RAW_TRANSFER.md
+++ b/examples/microbenchmarks/RAW_TRANSFER.md
@@ -45,7 +45,7 @@ export TPU_LIBRARY_PATH="/lib/libtpu.so"
 Execute the benchmark using the standard `bazel run` command. Use `--` to separate Bazel arguments from the benchmark's runtime flags:
 
 ```bash
-bazel run -c opt //tpu_raiden/core:raw_transfer_perf_test -- \
+bazel run -c opt //tpu_sync/core:raw_transfer_perf_test -- \
   --num_tpus=1 \
   --num_layers=256 \
   --num_blocks=32


### PR DESCRIPTION
`RAW_TRANSFER.md:48` documents the benchmark invocation as:

```bash
bazel run -c opt //tpu_raiden/core:raw_transfer_perf_test -- \
  --num_tpus=1 --num_layers=256 --num_blocks=32
```

That package path no longer exists after the move to `tpu_sync/`. The `cc_test` is declared in `tpu_sync/core/BUILD`, so the documented command fails to resolve the label as written.

One line, docs only.

## Rebased and reduced

This PR originally also fixed a stale `from tpu_raiden.api.jax import kv_cache_manager` in `jax_d2d_read_benchmark_runner.py`. That was fixed upstream in 71a4ad2 (#669), so I've rebased onto current `main` and dropped it — this is now the only remaining stale reference of the pair.

Verified against `2ee9c3f`.
