### PR TITLE
[DRAFT] Allocate host staging per transfer instead of fixed slots

### DIFF
--- a/tpu_sync/core/kv_cache_manager_with_transfer.cc
+++ b/tpu_sync/core/kv_cache_manager_with_transfer.cc
@@ -40,6 +40,7 @@
 #include <map>
 #include <memory>
 #include <mutex>
+#include <cstdlib>
 #include <optional>
 #include <ratio>
 #include <set>
@@ -492,6 +493,7 @@ KVCacheManagerWithTransfer::KVCacheManagerWithTransfer(
     if (num_slots_ <= 0) {
       throw std::invalid_argument("num_slots must be positive");
     }
+    dynamic_host_staging_ = DynamicHostStagingEnabled();
     auto status = ConfigureHostStagingSlots(num_slots_, max_blocks_);
     if (!status.ok()) {
       throw std::runtime_error(absl::StrCat(
@@ -500,7 +502,10 @@ KVCacheManagerWithTransfer::KVCacheManagerWithTransfer(
     if (num_layers() > 0) {
       ConfigureDataPortFromKvTransfer();
     }
-    status = InitializeSlotPool(num_slots_);
+    // Demand staging allocates per request, so the pool stays whole rather
+    // than being carved into fixed slots.
+    status = dynamic_host_staging_ ? absl::OkStatus()
+                                   : InitializeSlotPool(num_slots_);
     if (!status.ok()) {
       throw std::runtime_error(
           absl::StrCat("Failed to initialize slot pool: ", status.message()));
@@ -546,6 +551,7 @@ KVCacheManagerWithTransfer::KVCacheManagerWithTransfer(
     if (num_slots_ <= 0) {
       throw std::invalid_argument("num_slots must be positive");
     }
+    dynamic_host_staging_ = DynamicHostStagingEnabled();
     auto status = ConfigureHostStagingSlots(num_slots_, max_blocks_);
     if (!status.ok()) {
       throw std::runtime_error(absl::StrCat(
@@ -554,7 +560,10 @@ KVCacheManagerWithTransfer::KVCacheManagerWithTransfer(
     if (num_layers() > 0) {
       ConfigureDataPortFromKvTransfer();
     }
-    status = InitializeSlotPool(num_slots_);
+    // Demand staging allocates per request, so the pool stays whole rather
+    // than being carved into fixed slots.
+    status = dynamic_host_staging_ ? absl::OkStatus()
+                                   : InitializeSlotPool(num_slots_);
     if (!status.ok()) {
       throw std::runtime_error(
           absl::StrCat("Failed to initialize slot pool: ", status.message()));
@@ -588,6 +597,7 @@ KVCacheManagerWithTransfer::KVCacheManagerWithTransfer(
     if (num_slots_ <= 0) {
       throw std::invalid_argument("num_slots must be positive");
     }
+    dynamic_host_staging_ = DynamicHostStagingEnabled();
     auto status = ConfigureHostStagingSlots(num_slots_, max_blocks_);
     if (!status.ok()) {
       throw std::runtime_error(absl::StrCat(
@@ -596,7 +606,10 @@ KVCacheManagerWithTransfer::KVCacheManagerWithTransfer(
     if (num_layers > 0) {
       ConfigureDataPortFromKvTransfer();
     }
-    status = InitializeSlotPool(num_slots_);
+    // Demand staging allocates per request, so the pool stays whole rather
+    // than being carved into fixed slots.
+    status = dynamic_host_staging_ ? absl::OkStatus()
+                                   : InitializeSlotPool(num_slots_);
     if (!status.ok()) {
       throw std::runtime_error(
           absl::StrCat("Failed to initialize slot pool: ", status.message()));
@@ -1530,21 +1543,24 @@ void KVCacheManagerWithTransfer::StartRead(
   // (slot.block_ids -- the real, possibly non-contiguous host blocks).
   std::vector<int64_t> host_block_ids;
   int64_t recv_slot = -1;
+  std::vector<int> staged_host_blocks;
   if (local_host_block_ids.has_value()) {
     host_block_ids = *local_host_block_ids;
   } else if (!local_block_ids.empty()) {
     absl::MutexLock lock(mu_);
     absl::flat_hash_set<int64_t> unique_local_bids(local_block_ids.begin(),
                                                    local_block_ids.end());
-    if (static_cast<int64_t>(unique_local_bids.size()) > max_blocks_ ||
-        free_slots_.empty()) {
-      // Request larger than a slot, or staging pool exhausted: surface as a
-      // recv failure (the connector can recompute) rather than throwing.
+    RecvEntry staging;
+    auto staged = AcquireRecvStagingLocked(
+        static_cast<int64_t>(unique_local_bids.size()), &staging);
+    if (!staged.has_value()) {
+      // Request larger than the staging pool can seat: surface as a recv
+      // failure (the connector can recompute) rather than throwing.
       failed_recving_.insert(req_id);
       return;
     }
-    Slot slot = AcquireSlotLocked();
-    recv_slot = slot.slot_idx;
+    recv_slot = staging.slot_idx;
+    staged_host_blocks = std::move(staging.staged_host_blocks);
     absl::flat_hash_map<int64_t, int64_t> local_to_host;
     size_t host_block_idx = 0;
     host_block_ids.reserve(local_block_ids.size());
@@ -1552,7 +1568,7 @@ void KVCacheManagerWithTransfer::StartRead(
       int64_t local_bid = local_block_ids[k];
       auto it = local_to_host.find(local_bid);
       if (it == local_to_host.end()) {
-        int64_t host_bid = slot.block_ids[host_block_idx++];
+        int64_t host_bid = (*staged)[host_block_idx++];
         local_to_host[local_bid] = host_bid;
         host_block_ids.push_back(host_bid);
       } else {
@@ -1568,6 +1584,7 @@ void KVCacheManagerWithTransfer::StartRead(
     RecvEntry entry;
     entry.req_id = req_id;
     entry.slot_idx = recv_slot;
+    entry.staged_host_blocks = std::move(staged_host_blocks);
     entry.deadline = DeadlineFromNow();
     entry.start_time = std::chrono::steady_clock::now();
     entry.chip_block_ids = load_plan.h2d_local_block_ids;
@@ -1596,8 +1613,11 @@ void KVCacheManagerWithTransfer::StartRead(
   if (load_plan.num_blocks == 0) {
     absl::MutexLock lock(mu_);
     done_recving_.insert(req_id);
-    ReleaseSlotLocked(recv_slot);
-    active_recv_entries_.erase(uuid);
+    auto empty_it = active_recv_entries_.find(uuid);
+    if (empty_it != active_recv_entries_.end()) {
+      ReleaseRecvStagingLocked(&empty_it->second);
+      active_recv_entries_.erase(empty_it);
+    }
     return;
   }
 
@@ -1654,7 +1674,7 @@ void KVCacheManagerWithTransfer::StartRead(
       failed_recving_.insert(req_id);
       auto it = active_recv_entries_.find(uuid);
       if (it != active_recv_entries_.end()) {
-        ReleaseSlotLocked(it->second.slot_idx);
+        ReleaseRecvStagingLocked(&it->second);
         active_recv_entries_.erase(it);
       }
     }
@@ -1714,7 +1734,7 @@ KVCacheManagerWithTransfer::CompleteReadRaw() {
           LOG(INFO) << "CompleteReadRaw (polling completion): req_id="
                     << entry.req_id;
           done_recving_.insert(entry.req_id);
-          ReleaseSlotLocked(entry.slot_idx);
+          ReleaseRecvStagingLocked(&entry);
           active_recv_entries_.erase(it++);
           continue;
         }
@@ -1722,7 +1742,7 @@ KVCacheManagerWithTransfer::CompleteReadRaw() {
 
       if (entry.deadline <= now) {
         failed_recving_.insert(entry.req_id);
-        ReleaseSlotLocked(entry.slot_idx);
+        ReleaseRecvStagingLocked(&entry);
         timed_out_plan_uuids.push_back(it->first);
         active_recv_entries_.erase(it++);
       } else {
@@ -1882,6 +1902,53 @@ absl::Status KVCacheManagerWithTransfer::InitializeSlotPool(int64_t num_slots) {
   return absl::OkStatus();
 }
 
+bool KVCacheManagerWithTransfer::DynamicHostStagingEnabled() {
+  const char* raw = std::getenv("TPU_RAIDEN_DYNAMIC_HOST_STAGING");
+  return raw != nullptr && std::string(raw) == "1";
+}
+
+std::optional<std::vector<int64_t>>
+KVCacheManagerWithTransfer::AcquireRecvStagingLocked(int64_t num_blocks,
+                                                     RecvEntry* entry) {
+  if (num_blocks <= 0) return std::vector<int64_t>();
+  if (!dynamic_host_staging_) {
+    if (num_blocks > max_blocks_ || free_slots_.empty()) return std::nullopt;
+    Slot slot = AcquireSlotLocked();
+    entry->slot_idx = slot.slot_idx;
+    std::vector<int64_t> blocks;
+    blocks.reserve(num_blocks);
+    for (int64_t i = 0; i < num_blocks; ++i) {
+      blocks.push_back(slot.block_ids[i]);
+    }
+    return blocks;
+  }
+  // Lock the pages so the pool's LRU cannot evict staging that is mid-flight.
+  auto allocated = host_block_manager_->Allocate(static_cast<int>(num_blocks),
+                                                 /*lock=*/true);
+  if (!allocated.ok()) return std::nullopt;
+  entry->staged_host_blocks = *allocated;
+  std::vector<int64_t> blocks;
+  blocks.reserve(allocated->size());
+  for (int id : *allocated) blocks.push_back(static_cast<int64_t>(id));
+  return blocks;
+}
+
+void KVCacheManagerWithTransfer::ReleaseRecvStagingLocked(RecvEntry* entry) {
+  if (entry == nullptr) return;
+  ReleaseStagingLocked(entry->slot_idx, &entry->staged_host_blocks);
+}
+
+void KVCacheManagerWithTransfer::ReleaseStagingLocked(
+    int64_t slot_idx, std::vector<int>* staged_host_blocks) {
+  if (staged_host_blocks != nullptr && !staged_host_blocks->empty()) {
+    (void)host_block_manager_->Unlock(*staged_host_blocks);
+    (void)host_block_manager_->Deallocate(*staged_host_blocks);
+    staged_host_blocks->clear();
+    return;
+  }
+  ReleaseSlotLocked(slot_idx);
+}
+
 KVCacheManagerWithTransfer::Slot KVCacheManagerWithTransfer::AcquireSlot() {
   absl::MutexLock lock(mu_);
   return AcquireSlotLocked();
@@ -1906,12 +1973,21 @@ void KVCacheManagerWithTransfer::ReleaseSlotLocked(int64_t slot_idx) {
 
 void KVCacheManagerWithTransfer::ReleaseEntrySlotLocked(
     const std::shared_ptr<SendEntry>& entry) {
-  if (!entry || entry->slot_idx < 0 || entry->slot_released) return;
-  RemoveStagingReadinessLocked(entry->slot_idx);
+  if (!entry || entry->slot_released) return;
+  if (entry->slot_idx < 0 && entry->staged_host_blocks.empty()) return;
+  if (entry->slot_idx >= 0) {
+    RemoveStagingReadinessLocked(entry->slot_idx);
+  }
   for (int64_t block_id : entry->registered_block_ids) {
     active_producer_blocks_.erase(block_id);
   }
-  ReleaseSlotLocked(entry->slot_idx);
+  if (!entry->staged_host_blocks.empty()) {
+    (void)host_block_manager_->Unlock(entry->staged_host_blocks);
+    (void)host_block_manager_->Deallocate(entry->staged_host_blocks);
+    entry->staged_host_blocks.clear();
+  } else {
+    ReleaseSlotLocked(entry->slot_idx);
+  }
   entry->slot_released = true;
 }
 
@@ -2258,28 +2334,25 @@ void KVCacheManagerWithTransfer::StartPushInternal(
   // those host blocks to the consumer, keeping host offsets within the staging
   // pool. Writing D2H straight to host[src_block_id] overflows the host buffer
   // once a device block id exceeds num_host_blocks.
-  int64_t send_slot = -1;
   std::vector<int64_t> host_block_ids;
   {
     absl::MutexLock lock(mu_);
-    if (static_cast<int64_t>(src_block_ids.size()) > max_blocks_ ||
-        free_slots_.empty()) {
-      auto it = send_entries_.find(uuid);
-      if (it != send_entries_.end()) {
-        done_sending_.insert(it->second->req_id);
-        ReleaseEntrySlotLocked(it->second);
-        send_entries_.erase(it);
-      }
+    auto it = send_entries_.find(uuid);
+    if (it == send_entries_.end()) {
       return;
     }
-    Slot slot = AcquireSlotLocked();
-    send_slot = slot.slot_idx;
-    auto it = send_entries_.find(uuid);
-    if (it != send_entries_.end()) it->second->slot_idx = send_slot;
-    host_block_ids.reserve(src_block_ids.size());
-    for (size_t k = 0; k < src_block_ids.size(); ++k) {
-      host_block_ids.push_back(slot.block_ids[k]);
+    RecvEntry staging;
+    auto staged = AcquireRecvStagingLocked(
+        static_cast<int64_t>(src_block_ids.size()), &staging);
+    if (!staged.has_value()) {
+      done_sending_.insert(it->second->req_id);
+      ReleaseEntrySlotLocked(it->second);
+      send_entries_.erase(it);
+      return;
     }
+    it->second->slot_idx = staging.slot_idx;
+    it->second->staged_host_blocks = std::move(staging.staged_host_blocks);
+    host_block_ids = std::move(*staged);
   }
 
   // Coalesce contiguous (device,host) block runs into a few large copies. With
@@ -2589,6 +2662,7 @@ absl::Status KVCacheManagerWithTransfer::OnBlocksReceived(
 
   std::string req_id;
   int64_t recv_slot = -1;
+  std::vector<int> recv_staged;
   CopySpec h2d_copy;
   absl::flat_hash_map<int64_t, int64_t> host_to_chip;
   bool found = false;
@@ -2629,6 +2703,7 @@ absl::Status KVCacheManagerWithTransfer::OnBlocksReceived(
             metrics_collector_->RecordEnd(uuid);
           }
           found = true;
+          recv_staged = std::move(it->second.staged_host_blocks);
           active_recv_entries_.erase(it);
         }
       } else {
@@ -2653,7 +2728,7 @@ absl::Status KVCacheManagerWithTransfer::OnBlocksReceived(
   {
     absl::MutexLock lock(mu_);
     done_recving_.insert(req_id);
-    ReleaseSlotLocked(recv_slot);
+    ReleaseStagingLocked(recv_slot, &recv_staged);
   }
 
   LOG(INFO) << "OnBlocksReceived (Network + H2D complete): req_id=" << req_id
@@ -2837,8 +2912,11 @@ absl::Status KVCacheManagerWithTransfer::OnLayerReceived(size_t layer_idx,
   if (!future_or.ok()) {
     absl::MutexLock lock(mu_);
     failed_recving_.insert(req_id);
-    ReleaseSlotLocked(recv_slot);
-    active_recv_entries_.erase(uuid);
+    auto it = active_recv_entries_.find(uuid);
+    if (it != active_recv_entries_.end()) {
+      ReleaseRecvStagingLocked(&it->second);
+      active_recv_entries_.erase(it);
+    }
     return future_or.status();
   }
 
@@ -2869,7 +2947,7 @@ absl::Status KVCacheManagerWithTransfer::OnLayerReceived(size_t layer_idx,
           metrics_collector->RecordEnd(uuid);
         }
         done_recving_.insert(req_id);
-        ReleaseSlotLocked(recv_slot);
+        ReleaseRecvStagingLocked(&entry);
         active_recv_entries_.erase(uuid);
       }
     } else {
@@ -2877,7 +2955,7 @@ absl::Status KVCacheManagerWithTransfer::OnLayerReceived(size_t layer_idx,
                  << " for req_id: " << req_id
                  << ", error: " << status_or.status().ToString();
       failed_recving_.insert(req_id);
-      ReleaseSlotLocked(recv_slot);
+      ReleaseRecvStagingLocked(&entry);
       active_recv_entries_.erase(uuid);
     }
   });

--- a/tpu_sync/core/kv_cache_manager_with_transfer.cc
+++ b/tpu_sync/core/kv_cache_manager_with_transfer.cc
@@ -620,6 +620,14 @@ KVCacheManagerWithTransfer::KVCacheManagerWithTransfer(
 
 KVCacheManagerWithTransfer::~KVCacheManagerWithTransfer() {
   StopControlServer();
+  // Pull-serve workers read this object's state; nothing may be torn down
+  // while one is still running.
+  shutting_down_.store(true, std::memory_order_relaxed);
+  {
+    absl::MutexLock lock(pull_workers_mu_);
+    pull_workers_mu_.Await(absl::Condition(
+        +[](int* active) { return *active == 0; }, &active_pull_workers_));
+  }
   push_pool_.reset();
   pull_pool_.reset();
   if (host_block_manager_ && !all_slots_.empty()) {
@@ -1556,6 +1564,13 @@ void KVCacheManagerWithTransfer::StartRead(
     if (!staged.has_value()) {
       // Request larger than the staging pool can seat: surface as a recv
       // failure (the connector can recompute) rather than throwing.
+      LOG(ERROR) << "StartRead: cannot stage " << unique_local_bids.size()
+                 << " blocks for req_id=" << req_id
+                 << " (dynamic=" << dynamic_host_staging_
+                 << ", free_host_blocks="
+                 << host_block_manager_->num_free_blocks()
+                 << ", free_slots=" << free_slots_.size()
+                 << ", max_blocks=" << max_blocks_ << ")";
       failed_recving_.insert(req_id);
       return;
     }
@@ -1694,7 +1709,9 @@ KVCacheManagerWithTransfer::CompleteReadRaw() {
     for (auto it = send_entries_.begin(); it != send_entries_.end();) {
       const auto& entry = it->second;
       if (entry->deadline <= now) {
-        done_sending_.insert(entry->req_id);
+        // Nothing pulled this entry within its deadline; the bytes were
+        // never sent, so the transfer failed.
+        failed_recving_.insert(entry->req_id);
         ReleaseEntrySlotLocked(entry);
         timed_out_plan_uuids.push_back(it->first);
         it = send_entries_.erase(it);
@@ -1923,9 +1940,14 @@ KVCacheManagerWithTransfer::AcquireRecvStagingLocked(int64_t num_blocks,
     return blocks;
   }
   // Lock the pages so the pool's LRU cannot evict staging that is mid-flight.
+  // An allocation miss is only reported back; this helper neither retries
+  // nor logs. The producer retries it until its deadline, the consumer
+  // fails it at once, and each logs its own verdict.
   auto allocated = host_block_manager_->Allocate(static_cast<int>(num_blocks),
                                                  /*lock=*/true);
-  if (!allocated.ok()) return std::nullopt;
+  if (!allocated.ok()) {
+    return std::nullopt;
+  }
   entry->staged_host_blocks = *allocated;
   std::vector<int64_t> blocks;
   blocks.reserve(allocated->size());
@@ -2150,6 +2172,10 @@ void KVCacheManagerWithTransfer::StopControlServer() {
       RemoveStagingReadinessLocked(staging_readiness_.begin()->first);
     }
   }
+  // Wake workers parked in ProcessPullStream waiting for a send entry that
+  // will never arrive, so their loops observe stopping_ and the pools can
+  // join them.
+  cv_.SignalAll();
   if (control_fd_ >= 0) {
     shutdown(control_fd_, SHUT_RDWR);
     close(control_fd_);
@@ -2319,11 +2345,87 @@ void KVCacheManagerWithTransfer::ProcessPullStream(
     }
   }
 
+  {
+    absl::MutexLock lock(pull_workers_mu_);
+    ++active_pull_workers_;
+  }
   std::thread([this, uuid = req.uuid, remote_data_endpoints, src_block_ids,
                dst_block_ids]() {
     StartPushInternal(uuid, remote_data_endpoints, src_block_ids,
                       dst_block_ids);
+    absl::MutexLock lock(pull_workers_mu_);
+    --active_pull_workers_;
   }).detach();
+}
+
+bool KVCacheManagerWithTransfer::AcquireSendStagingWithRetry(
+    uint64_t uuid, const std::vector<int64_t>& src_block_ids,
+    std::vector<int64_t>* host_block_ids) {
+  // The entry's deadline, set when the producer registered the request,
+  // bounds the whole transfer; the wait for staging shares it rather than
+  // starting a later one of its own.
+  std::chrono::steady_clock::time_point stage_deadline;
+  while (true) {
+    if (shutting_down_.load(std::memory_order_relaxed)) {
+      return false;  // the manager is being destroyed; its state goes with it
+    }
+    {
+      absl::MutexLock lock(mu_);
+      auto it = send_entries_.find(uuid);
+      if (it == send_entries_.end()) {
+        return false;  // request cancelled while waiting for staging
+      }
+      stage_deadline = it->second->deadline;
+      // Staging that can never seat this request fails it now rather than
+      // after the deadline: a fixed slot holds max_blocks_ pages, the
+      // per-transfer pool holds total_blocks() pages.
+      const int64_t capacity = dynamic_host_staging_
+                                   ? host_block_manager_->total_blocks()
+                                   : max_blocks_;
+      if (static_cast<int64_t>(src_block_ids.size()) > capacity) {
+        LOG(ERROR) << "StartPushInternal: request " << it->second->req_id
+                   << " needs " << src_block_ids.size() << " blocks but "
+                   << (dynamic_host_staging_ ? "the host staging pool holds "
+                                             : "a staging slot holds ")
+                   << capacity;
+        failed_recving_.insert(it->second->req_id);
+        ReleaseEntrySlotLocked(it->second);
+        send_entries_.erase(it);
+        return false;
+      }
+      RecvEntry staging;
+      auto staged = AcquireRecvStagingLocked(
+          static_cast<int64_t>(src_block_ids.size()), &staging);
+      if (staged.has_value()) {
+        it->second->slot_idx = staging.slot_idx;
+        it->second->staged_host_blocks = std::move(staging.staged_host_blocks);
+        *host_block_ids = std::move(*staged);
+        return true;
+      }
+    }
+    // Staging exhausted: wait for in-flight sends to hand blocks back
+    // instead of reporting a send that never happened. The consumer's own
+    // deadline still bounds the total wait.
+    if (std::chrono::steady_clock::now() >= stage_deadline) {
+      absl::MutexLock lock(mu_);
+      auto it = send_entries_.find(uuid);
+      if (it != send_entries_.end()) {
+        LOG(ERROR) << "StartPushInternal: staging exhausted serving "
+                   << it->second->req_id << " (" << src_block_ids.size()
+                   << " blocks; free_host_blocks="
+                   << host_block_manager_->num_free_blocks()
+                   << ", total_host_blocks="
+                   << host_block_manager_->total_blocks()
+                   << ", free_slots=" << free_slots_.size()
+                   << "); reporting transfer failure";
+        failed_recving_.insert(it->second->req_id);
+        ReleaseEntrySlotLocked(it->second);
+        send_entries_.erase(it);
+      }
+      return false;
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
 }
 
 void KVCacheManagerWithTransfer::StartPushInternal(
@@ -2335,24 +2437,8 @@ void KVCacheManagerWithTransfer::StartPushInternal(
   // pool. Writing D2H straight to host[src_block_id] overflows the host buffer
   // once a device block id exceeds num_host_blocks.
   std::vector<int64_t> host_block_ids;
-  {
-    absl::MutexLock lock(mu_);
-    auto it = send_entries_.find(uuid);
-    if (it == send_entries_.end()) {
-      return;
-    }
-    RecvEntry staging;
-    auto staged = AcquireRecvStagingLocked(
-        static_cast<int64_t>(src_block_ids.size()), &staging);
-    if (!staged.has_value()) {
-      done_sending_.insert(it->second->req_id);
-      ReleaseEntrySlotLocked(it->second);
-      send_entries_.erase(it);
-      return;
-    }
-    it->second->slot_idx = staging.slot_idx;
-    it->second->staged_host_blocks = std::move(staging.staged_host_blocks);
-    host_block_ids = std::move(*staged);
+  if (!AcquireSendStagingWithRetry(uuid, src_block_ids, &host_block_ids)) {
+    return;
   }
 
   // Coalesce contiguous (device,host) block runs into a few large copies. With
@@ -2386,15 +2472,18 @@ void KVCacheManagerWithTransfer::StartPushInternal(
                                      d2h_copy.sizes, /*slot_idx=*/std::nullopt,
                                      /*layer_idx=*/l);
     if (!future_or.ok()) {
+      // A copy that cannot even be issued fails the transfer; the worker
+      // thread has no caller for an exception to reach.
+      LOG(ERROR) << "StartPushInternal: failed to issue D2H for layer " << l
+                 << ": " << future_or.status();
       absl::MutexLock lock(mu_);
       auto it = send_entries_.find(uuid);
       if (it != send_entries_.end()) {
-        done_sending_.insert(it->second->req_id);
+        failed_recving_.insert(it->second->req_id);
         ReleaseEntrySlotLocked(it->second);
         send_entries_.erase(it);
       }
-      ThrowStatus("Failed to issue D2H in StartPushInternal layer loop",
-                  future_or.status());
+      return;
     }
     entry->d2h_layer_futures.push_back(std::move(future_or.value()));
   }
@@ -2431,7 +2520,7 @@ void KVCacheManagerWithTransfer::SendNextLayer(uint64_t uuid, size_t l) {
       absl::MutexLock lock(mu_);
       auto it = send_entries_.find(uuid);
       if (it != send_entries_.end()) {
-        done_sending_.insert(it->second->req_id);
+        failed_recving_.insert(it->second->req_id);
         ReleaseEntrySlotLocked(it->second);
         send_entries_.erase(it);
       }
@@ -2470,7 +2559,7 @@ void KVCacheManagerWithTransfer::SendNextLayer(uint64_t uuid, size_t l) {
               absl::MutexLock lock(mu_);
               if (auto it = send_entries_.find(uuid);
                   it != send_entries_.end()) {
-                done_sending_.insert(entry->req_id);
+                failed_recving_.insert(entry->req_id);
                 ReleaseEntrySlotLocked(entry);
                 send_entries_.erase(it);
               }

--- a/tpu_sync/core/kv_cache_manager_with_transfer.h
+++ b/tpu_sync/core/kv_cache_manager_with_transfer.h
@@ -429,6 +429,13 @@ class KVCacheManagerWithTransfer : public kv_cache::KVCacheManagerBase {
   absl::flat_hash_map<uint64_t, std::shared_ptr<PoolReshardSendEntry>>
       active_pool_reshard_sends_;
 
+  // Acquires host staging for a pull-serve send, retrying while other
+  // transfers hand blocks back, bounded by the entry's deadline. Returns
+  // false when the transfer was failed or cancelled instead; the caller
+  // has nothing left to do.
+  bool AcquireSendStagingWithRetry(uint64_t uuid,
+                                   const std::vector<int64_t>& src_block_ids,
+                                   std::vector<int64_t>* host_block_ids);
   void StartPushInternal(uint64_t uuid,
                          const std::vector<std::string>& remote_data_endpoints,
                          const std::vector<int64_t>& src_block_ids,
@@ -470,6 +477,12 @@ class KVCacheManagerWithTransfer : public kv_cache::KVCacheManagerBase {
   // fixed slots. A short request then costs its own pages rather than a
   // whole slot, so the same pool seats more transfers at once.
   bool dynamic_host_staging_ = false;
+
+  // Pull-serve workers launched by ProcessPullStream. The destructor waits
+  // for them, and shutting_down_ ends a worker's staging wait early.
+  std::atomic<bool> shutting_down_{false};
+  absl::Mutex pull_workers_mu_;
+  int active_pull_workers_ ABSL_GUARDED_BY(pull_workers_mu_) = 0;
   double timeout_s_ = 120.0;
   bool unsafe_skip_buffer_lock_ = true;
 

--- a/tpu_sync/core/kv_cache_manager_with_transfer.h
+++ b/tpu_sync/core/kv_cache_manager_with_transfer.h
@@ -254,6 +254,9 @@ class KVCacheManagerWithTransfer : public kv_cache::KVCacheManagerBase {
     std::string req_id;
     uint64_t uuid = 0;
     int64_t slot_idx = -1;
+    // Host blocks held under demand staging, released on completion. Empty
+    // when the transfer holds a fixed slot instead.
+    std::vector<int> staged_host_blocks;
     int64_t num_blocks = 0;
     int64_t registered_num_blocks = 0;
     int64_t total_bytes = 0;
@@ -332,10 +335,21 @@ class KVCacheManagerWithTransfer : public kv_cache::KVCacheManagerBase {
   static void ValidateRequestedBlocks(
       const SendEntry& entry, const std::vector<int64_t>& requested_block_ids);
 
+  static bool DynamicHostStagingEnabled();
   absl::Status InitializeSlotPool(int64_t num_slots);
   Slot AcquireSlot();
   Slot AcquireSlotLocked();
   void ReleaseSlotLocked(int64_t slot_idx);
+  struct RecvEntry;  // defined below; staging helpers take it by pointer
+  // Host staging for one incoming read: exactly `num_blocks` blocks under
+  // demand staging, a whole fixed slot otherwise. Returns nullopt when the
+  // staging pool cannot seat the request.
+  std::optional<std::vector<int64_t>> AcquireRecvStagingLocked(
+      int64_t num_blocks, RecvEntry* entry);
+  void ReleaseRecvStagingLocked(RecvEntry* entry);
+  // Same, for paths that have already taken the entry's staging out of it.
+  void ReleaseStagingLocked(int64_t slot_idx,
+                            std::vector<int>* staged_host_blocks);
   void ReleaseEntrySlotLocked(const std::shared_ptr<SendEntry>& entry);
 
   void StartControlServer();
@@ -365,6 +379,9 @@ class KVCacheManagerWithTransfer : public kv_cache::KVCacheManagerBase {
   struct RecvEntry {
     std::string req_id;
     int64_t slot_idx = -1;  // host staging slot to release on completion
+    // Host blocks held under demand staging, released on completion. Empty
+    // when the transfer holds a fixed slot instead.
+    std::vector<int> staged_host_blocks;
     CopySpec h2d_copy;
     std::vector<int64_t> chip_block_ids;
     absl::flat_hash_map<int64_t, int64_t> host_to_chip;
@@ -449,6 +466,10 @@ class KVCacheManagerWithTransfer : public kv_cache::KVCacheManagerBase {
   int local_data_port_ = 0;
   int64_t max_blocks_ = 0;
   int64_t num_slots_ = 0;
+  // Allocate host staging per request instead of carving the pool into
+  // fixed slots. A short request then costs its own pages rather than a
+  // whole slot, so the same pool seats more transfers at once.
+  bool dynamic_host_staging_ = false;
   double timeout_s_ = 120.0;
   bool unsafe_skip_buffer_lock_ = true;
 


### PR DESCRIPTION
## TL;DR

- Host staging for disaggregated KV transfer is allocated **per transfer**
  (`TPU_RAIDEN_DYNAMIC_HOST_STAGING=1`) instead of in fixed worst-case slots.
- **8× less host memory for the same load, measured** (36 → 4.5 GiB per host),
  zero failed transfers, throughput unchanged. At long context lengths fixed
  slots stop fitting in the machine at all (table below).
- An exhausted pool now **fails loudly** with a reason instead of reporting a
  transfer that never happened.
- Next, in #736 (same allocator): the resharding path, which today mirrors
  the whole device KV pool on the host — **452 GiB → ~2.3 GiB per host** expected
  for the same load (validated end to end on a small model in #736).

## Why it matters — host memory per 8-rank host, gpt-oss-120b TP8

| scenario | fixed slots (today) | on demand (this PR) |
|---|---|---|
| 8k context, 64-way concurrency — **measured** | 36 GiB (64 slots, else requests fail) | **4.5 GiB**, zero failures, same throughput |
| 128k context, same traffic — projected | 576 GiB (64 slots); 36 GiB buys only 4 transfers in flight | ~14 GiB |
| 1M context, mostly 8k requests — projected | 4.6 TiB (64 slots); 288 GiB buys 4 in flight | ~100 GiB for 64 short + 1 long in flight |
| **Resharding** (asymmetric TP), 8k context, same load — **#736** (measured on Qwen3-1.7B: host mirror → half the device pool at equal accuracy and throughput; gpt-oss figures projected) | **452 GiB** (full host mirror of the device KV pool, both sides) | **~2.3 GiB** (in-flight pages only) |

Fixed slots are sized for the longest request the server accepts × the
concurrency wanted; on-demand staging is sized for the bytes actually in
flight. Resharding today goes further and mirrors the entire device KV pool on
the host so that block ids can be resolved by identity; the same allocator plus
a per-plan id map removes that requirement — that is #736, stacked on this PR.

## What changes

| commit | change |
|---|---|
| Stage disaggregation transfers on demand instead of in fixed slots | Both sides (`StartRead`, `StartPushInternal`) allocate exactly the pages they stage from the existing host block manager, locked for the transfer's lifetime, and return them on completion/timeout/error. Copy plans already address host blocks explicitly: nothing changes downstream or on the wire. Off by default; reshard/pool-plan paths untouched. |
| Fail loudly when transfer staging is exhausted | Producer waits for staging to free (bounded by the transfer deadline) instead of marking the send done without transferring; a request that still cannot be seated, or can never fit, is reported as a failure. Both sides log request, pages asked, pages free. |

## Validation

| | |
|---|---|
| Test | End-to-end disaggregated-prefill serving (prefill/decode split as in vLLM's P/D disaggregation), SGLang on TPU with raiden as the KV transport |
| Hardware / model | 1 prefill host + 1 decode host, v7x, TP8 each; gpt-oss-120b (hybrid: two engines per request) |
| KV / context | 64-token pages, 0.56 MiB per page per rank; context length 8192 |
| Load | 96 short prompts at 32-way burst; 64 × 512-tok; 32 × 4096-tok; 3 × 600 × 2048-tok paced; 200-question gsm8k |
| Per-request path | each decode rank pulls the request's pages from its prefill peer via `StartRead` / pull-serve |
| Metric | raiden `failed_recving` per consumer rank ("failed reads"); the serving layer retries, so client success rates hide failures |
| Build | jax + torch wheels via `ci/build_wheel.sh`; each commit builds standalone; the new path is present in all 3 torch ABI extensions |

**Results**

| claim | flag off | flag on |
|---|---|---|
| Failed reads / timeouts, all phases | 0 / 0 | **0 / 0** |
| gsm8k accuracy | 0.870 | 0.850 (pre-change baseline 0.850) |
| Pool needed for this load, zero failures | 8192 pages = 4.50 GiB/rank = 36 GiB/host | **1024 pages = 0.56 GiB/rank = 4.5 GiB/host** |
| Same load at a pool fixed slots *can't* serve | 4 slots → **1112 failed reads across 139 requests** | — |
| Throughput at the ⅛ pool (512-tok / 4096-tok / burst, req/s) | 9.7 / 4.9 / 21.2 (full pool) | 9.1 / 4.8 / 20.6 |

**Throughput, same 8192-page pool, flag off vs on** (req/s · mean/p99 TTFT ms)

| phase | flag off | flag on |
|---|---|---|
| 96 short prompts, 32-way burst | 21.2 · 644/800 | 22.0 · 722/1230 |
| 64 × 512-tok | 9.7 · 1793/2540 | 8.6 · 1688/2735 |
| 32 × 4096-tok | 4.9 · 3012/5590 | 4.6 · 3216/5903 |
| 600 × 2048-tok, paced (×3) | 3.86–3.87 · 79–204 | 3.86–3.87 · 90–217 |

Run-to-run variation, measured with two flag-off runs: the three unpaced
phases (the 32-way burst and the 64 × 512-token and 32 × 4096-token runs,
each a few seconds long, requests sent as fast as the server accepts them)
differ from each other by up to 12% in req/s; the paced phase (600 requests
offered at a fixed 4 req/s over about 2.5 minutes) is identical across runs,
as expected while the server keeps up with the offered rate.

**Exhaustion behaviour:** offered load above pool capacity → reads wait
(bounded by the transfer deadline); a read that can never fit fails with a
logged reason (request, blocks asked, blocks free). Before: producer reported
success without transferring, consumer timed out.

**Found during validation, fixed here:** the first build leaked staging on
every successful read (event-driven completion paths still released by slot
index). The added error line made it diagnosable in one run.

## Follow-ups (not in this PR)

- Resharding: replace the identity-addressed host mirror with per-plan host
  staging on both sides (452 GiB → ~2.3 GiB per host projected for this load)
  — #736.
- Consumer-side wait-with-deadline on a transiently full pool (today the
  consumer fails fast while the producer waits).
- Longer mixed-size soak for fragmentation before making the flag the default
  (the paced phase ran 1800 transfers without drift).


