### PR TITLE
raw_transfer: compile across the XLA PjRtRawBufferInterface->CommonPjRtRawBuffer rename

### DIFF
--- a/tpu_sync/core/raw_transfer_core.h
+++ b/tpu_sync/core/raw_transfer_core.h
@@ -20,6 +20,7 @@
 #include <memory>
 #include <stdexcept>
 #include <string>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -42,6 +43,18 @@
 #include "xla/tsl/concurrency/ref_count.h"
 
 namespace raiden {
+
+// Version-agnostic name for XLA's common raw-buffer type.
+//
+// XLA renamed this class from `xla::PjRtRawBufferInterface` to
+// `xla::CommonPjRtRawBuffer` (see xla/pjrt/raw_buffer.h). Naming the concrete
+// class directly makes this header fail to compile against XLA revisions on the
+// other side of that rename. The `xla::PjRtRawBufferRef` alias
+// (`tsl::RCReference<...>`) is stable across the rename, so we derive the
+// pointee type from it. This keeps `raw_transfer_core.h` buildable against both
+// pre- and post-rename XLA without a preprocessor version gate.
+using RaidenRawBuffer =
+    std::remove_reference_t<decltype(*std::declval<xla::PjRtRawBufferRef>())>;
 
 struct RawBufferHolder {
   const PJRT_Api* c_api;
@@ -150,7 +163,7 @@ struct RaidenBufferHandle {
   bool is_common_buffer = false;
 
   // For CommonPjRtBuffer:
-  tsl::RCReference<xla::PjRtRawBufferInterface> common_raw_buffer;
+  tsl::RCReference<RaidenRawBuffer> common_raw_buffer;
   std::shared_ptr<xla::CommonPjRtBuffer::ScopedHold> common_hold;
 
   // For PjRtCApiBuffer:
@@ -179,8 +192,8 @@ struct RaidenBufferHandle {
         return hold.status();
       }
       // Workaround for OSS type discrepancies.
-      result.common_raw_buffer = tsl::FormRef<xla::PjRtRawBufferInterface>(
-          reinterpret_cast<xla::PjRtRawBufferInterface*>(
+      result.common_raw_buffer = tsl::FormRef<RaidenRawBuffer>(
+          reinterpret_cast<RaidenRawBuffer*>(
               hold.buffer()->raw_buffer().get()));
       if (!unsafe_skip_buffer_lock) {
         result.common_hold =
@@ -213,7 +226,7 @@ struct RaidenBufferHandle {
   }
 
   static absl::StatusOr<RaidenBufferHandle> AcquireFromRaw(
-      xla::PjRtRawBufferInterface* raw_buf, const xla::Shape& shape,
+      RaidenRawBuffer* raw_buf, const xla::Shape& shape,
       bool unsafe_skip_buffer_lock = false) {
     RaidenBufferHandle result;
     result.shape = shape;


### PR DESCRIPTION
## Problem

`tpu_sync/core/raw_transfer_core.h` names `xla::PjRtRawBufferInterface` directly (the `common_raw_buffer` field, the `tsl::FormRef<...>` in `Acquire`, and the `AcquireFromRaw` parameter). XLA has since **renamed** that class to `xla::CommonPjRtRawBuffer` (see `xla/pjrt/raw_buffer.h`, where `class CommonPjRtRawBuffer : public PjRtRawBuffer` and `using PjRtRawBufferRef = tsl::RCReference<CommonPjRtRawBuffer>`).

Because the concrete class name is hard-coded, this header **fails to compile against XLA revisions on the post-rename side**:

```
error: 'PjRtRawBufferInterface' is not a member of 'xla'; did you mean 'PjRtRawBufferRef'?
error: 'struct raiden::RaidenBufferHandle' has no member named 'common_raw_buffer'
```

(The `common_raw_buffer` / `memory_space` cascade errors are all downstream of the single type-name failure.)

This is not hypothetical: when a prebuilt `_raw_transfer.so` (built against a pre-rename XLA) is loaded against a runtime whose XLA is on the other side of the rename, the mismatch surfaces at runtime as `RuntimeError: Not a PjRt compatible array` from `jax_utils.h` (`CastToPjRtCompatibleArray` returns null across the ABI), and every transfer silently moves 0 bytes because the exception is swallowed inside producer threads. Building the `.so` version-matched to the target runtime is the real fix — but the source only compiles against one side of the rename at a time.

## Fix (version-agnostic, no preprocessor gate)

The `xla::PjRtRawBufferRef` alias (`tsl::RCReference<...>`) is **stable across the rename** — only the pointee class name changed. Derive the concrete type from it via `decltype` and use that everywhere:

```cpp
using RaidenRawBuffer =
    std::remove_reference_t<decltype(*std::declval<xla::PjRtRawBufferRef>())>;
```

`RaidenRawBuffer` resolves to `PjRtRawBufferInterface` on pre-rename XLA and `CommonPjRtRawBuffer` on post-rename XLA, so `raw_transfer_core.h` builds against **both** without a version macro. The 4 usages are switched to `RaidenRawBuffer`; `<type_traits>` is added for `std::remove_reference_t` (`<utility>` for `std::declval` is already included).

Verified: the `decltype` idiom compiles under `-std=c++17` and a `static_assert` confirms the alias resolves to the correct concrete type on each side of the rename.

1 file changed, +17/-4.

— via [Navi](https://navibot.dev?utm_source=github&utm_medium=pull_request&ref=dengcchi) on behalf of Loki Chen
