### PR TITLE
[DRAFT] Stage resharding transfers in plan-allocated host blocks

### DIFF
--- a/tpu_sync/api/torch/kv_cache_manager.py
+++ b/tpu_sync/api/torch/kv_cache_manager.py
@@ -207,6 +207,25 @@ class KVCacheManager:
     """Removes a previously registered strided push plan."""
     self._impl.unregister_active_plan(uuid)
 
+  def plan_host_blocks(self, uuid: int, block_ids: Sequence[int]) -> List[int]:
+    """Host blocks staging ``block_ids`` under a registered plan.
+
+    A sender stages its device blocks into these before pushing.
+
+    Args:
+      uuid: The plan's identifier, as passed to ``register_active_plan``.
+      block_ids: Device block ids the plan names.
+
+    Returns:
+      One host block id per entry of ``block_ids``; the ids themselves when
+      the plan stages blocks at their own ids.
+
+    Raises:
+      RuntimeError: The plan is not registered, or a block is not staged by
+        the plan.
+    """
+    return [int(b) for b in self._impl.plan_host_blocks(uuid, list(block_ids))]
+
   def push_registered_plan(
       self,
       uuid: int,

--- a/tpu_sync/core/BUILD
+++ b/tpu_sync/core/BUILD
@@ -683,9 +683,9 @@ cc_test(
         "//tpu_sync/telemetry:mock_metrics_backend",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/types:span",
+        "@com_google_absl//absl/time",
         "@com_google_googletest//:gtest_main",
-    ],
-)
+    ],)
 
 cc_test(
     name = "kv_cache_manager_perf_test",

--- a/tpu_sync/core/kv_cache_manager_with_transfer.cc
+++ b/tpu_sync/core/kv_cache_manager_with_transfer.cc
@@ -688,16 +688,69 @@ int64_t KVCacheManagerWithTransfer::NotifyForRead(
 absl::Status KVCacheManagerWithTransfer::RegisterActivePlan(
     uint64_t uuid, const ::tpu_sync::rpc::StartTransferRequest& request,
     bool is_sender) {
-  // 1. Call base class implementation to register the plan in active_plans_
-  TF_RETURN_IF_ERROR(kv_cache::KVCacheManagerBase::RegisterActivePlan(
-      uuid, request, is_sender));
+  // Registration is one indivisible step: a concurrent unregister or a
+  // second registration of the same uuid waits for it, so a plan is never
+  // visible without the staging and receive state that belong to it.
+  absl::MutexLock lifecycle(plan_lifecycle_mu_);
+  if (kv_cache::KVCacheManagerBase::HasActivePlan(uuid)) {
+    return absl::AlreadyExistsError(
+        absl::StrCat("Plan with UUID ", uuid, " is already registered!"));
+  }
+  const uint64_t generation = ++plan_generation_counter_;
+  // Under demand staging a plan's device blocks are staged in host blocks
+  // allocated for the plan, so the host mirror no longer has to span the
+  // device block space. Pool-addressed plans keep their own addressing.
+  absl::flat_hash_map<kv_cache::DeviceBlockId, kv_cache::HostBlockId>
+      host_block_of;
+  std::vector<int> plan_blocks;
+  if (dynamic_host_staging_ && request.pool_groups_size() == 0) {
+    std::vector<int64_t> device_blocks;
+    absl::flat_hash_set<int64_t> seen;
+    for (const auto& [src_shard, schedule] : request.shard_push_schedules()) {
+      for (const auto& e : schedule.entries()) {
+        int64_t id = is_sender ? e.src_block_id() : e.dst_block_id();
+        if (seen.insert(id).second) device_blocks.push_back(id);
+      }
+    }
+    if (!device_blocks.empty()) {
+      absl::MutexLock lock(mu_);
+      auto allocated = host_block_manager_->Allocate(
+          static_cast<int>(device_blocks.size()), /*lock=*/true);
+      if (!allocated.ok()) {
+        return absl::ResourceExhaustedError(absl::StrCat(
+            "cannot stage ", device_blocks.size(), " blocks for plan ", uuid,
+            ": ", allocated.status().message()));
+      }
+      plan_blocks = *allocated;
+      for (size_t i = 0; i < device_blocks.size(); ++i) {
+        host_block_of[device_blocks[i]] = plan_blocks[i];
+      }
+    }
+  }
+
+
+  // Staging ownership is settled before the plan is published. An HBM
+  // receiver's blocks belong to its receive entry and return when the
+  // upload settles; a sender's blocks, and a host-memory receiver's,
+  // belong to the plan and return when it is unregistered.
+  const bool hbm_receiver =
+      !is_sender && request.dst_mem_type() == ::tpu_sync::rpc::MEMORY_TYPE_HBM;
+  if (!plan_blocks.empty() && !hbm_receiver) {
+    absl::MutexLock lock(mu_);
+    plan_staging_[uuid] = plan_blocks;
+  }
 
   // 2. If we are the receiver and the destination memory type is HBM,
   //    populate active_recv_entries_ to enable automatic H2D copy!
-  if (!is_sender &&
-      request.dst_mem_type() == ::tpu_sync::rpc::MEMORY_TYPE_HBM) {
+  if (hbm_receiver) {
     absl::MutexLock lock(mu_);
     RecvEntry recv_entry;
+    recv_entry.staged_host_blocks = std::move(plan_blocks);
+    // Once its receive settles, a demand-staged receiver plan would map
+    // host blocks that are already freed; the plan is therefore dropped
+    // together with the receive instead of outliving it.
+    recv_entry.unregister_on_settle = !recv_entry.staged_host_blocks.empty();
+    recv_entry.plan_generation = generation;
     std::string req_id = request.req_id().empty()
                              ? absl::StrCat("resharded_transfer_", uuid)
                              : request.req_id();
@@ -710,8 +763,10 @@ absl::Status KVCacheManagerWithTransfer::RegisterActivePlan(
       absl::flat_hash_set<std::pair<int, int>>
           unique_transfers_from_this_source;
       for (const auto& push_entry : schedule.entries()) {
-        recv_entry.host_to_chip[push_entry.dst_block_id()] =
-            push_entry.dst_block_id();
+        const int64_t dst = push_entry.dst_block_id();
+        auto hb = host_block_of.find(dst);
+        recv_entry.host_to_chip[hb == host_block_of.end() ? dst : hb->second] =
+            dst;
         unique_transfers_from_this_source.insert(
             {push_entry.src_block_id(), push_entry.dst_block_id()});
         unique_dst_blocks.insert(push_entry.dst_block_id());
@@ -723,14 +778,22 @@ absl::Status KVCacheManagerWithTransfer::RegisterActivePlan(
     recv_entry.deadline = DeadlineFromNow();
     recv_entry.start_time = std::chrono::steady_clock::now();
 
-    // Populate h2d_copy spec for unique destination blocks
-    std::vector<int64_t> h2d_host_block_ids(unique_dst_blocks.begin(),
-                                            unique_dst_blocks.end());
-    std::vector<int64_t> h2d_local_block_ids =
-        h2d_host_block_ids;  // 1-to-1 mapping
+    // H2D reads each destination block from wherever it was staged.
+    std::vector<int64_t> h2d_local_block_ids(unique_dst_blocks.begin(),
+                                             unique_dst_blocks.end());
+    std::vector<int64_t> h2d_host_block_ids;
+    h2d_host_block_ids.reserve(h2d_local_block_ids.size());
+    for (int64_t dst : h2d_local_block_ids) {
+      auto hb = host_block_of.find(dst);
+      h2d_host_block_ids.push_back(hb == host_block_of.end() ? dst
+                                                             : hb->second);
+    }
     recv_entry.h2d_copy =
         BuildCoalescedCopySpec(h2d_host_block_ids, h2d_local_block_ids);
 
+    if (total_blocks == 0) {
+      ReleaseRecvStagingLocked(&recv_entry);
+    }
     if (total_blocks > 0) {
       active_recv_entries_[uuid] = std::move(recv_entry);
       LOG(INFO) << "RegisterActivePlan (Receiver): Populated "
@@ -739,6 +802,26 @@ absl::Status KVCacheManagerWithTransfer::RegisterActivePlan(
                 << " total physical block-pushes (including duplicates across "
                    "sources) for automatic H2D.";
     }
+  }
+
+  // Publish the plan last: pushes resolve through it, so everything they
+  // may touch exists by the time it is visible.
+  absl::Status registered = kv_cache::KVCacheManagerBase::RegisterActivePlan(
+      uuid, request, is_sender, host_block_of, generation);
+  if (!registered.ok()) {
+    absl::MutexLock lock(mu_);
+    auto staged = plan_staging_.find(uuid);
+    if (staged != plan_staging_.end()) {
+      (void)host_block_manager_->Unlock(staged->second);
+      (void)host_block_manager_->Deallocate(staged->second);
+      plan_staging_.erase(staged);
+    }
+    auto recv = active_recv_entries_.find(uuid);
+    if (recv != active_recv_entries_.end()) {
+      ReleaseRecvStagingLocked(&recv->second);
+      active_recv_entries_.erase(recv);
+    }
+    return registered;
   }
   return absl::OkStatus();
 }
@@ -1450,6 +1533,49 @@ absl::Status KVCacheManagerWithTransfer::PoolReshardRegisterRecv(
   return absl::OkStatus();
 }
 
+absl::Status KVCacheManagerWithTransfer::UnregisterActivePlan(uint64_t uuid) {
+  absl::MutexLock lifecycle(plan_lifecycle_mu_);
+  bool deferred = false;
+  {
+    absl::MutexLock lock(mu_);
+    auto it = plan_staging_.find(uuid);
+    if (it != plan_staging_.end()) {
+      (void)host_block_manager_->Unlock(it->second);
+      (void)host_block_manager_->Deallocate(it->second);
+      plan_staging_.erase(it);
+    }
+    // A receive still in flight keeps its plan: pushes the transport has
+    // already accepted must keep resolving into the plan's staging blocks.
+    // The plan is dropped when the receive completes, fails, or times out.
+    auto recv = active_recv_entries_.find(uuid);
+    if (recv != active_recv_entries_.end() && !recv->second.is_pool_reshard) {
+      recv->second.unregister_on_settle = true;
+      deferred = true;
+    }
+  }
+  if (deferred) return absl::OkStatus();
+  return kv_cache::KVCacheManagerBase::UnregisterActivePlan(uuid);
+}
+
+void KVCacheManagerWithTransfer::UnregisterSettledPlan(uint64_t uuid,
+                                                       uint64_t generation) {
+  // Serialized with registration so cleanup for one registration can never
+  // remove a newer one reusing the uuid, or race its progress counters.
+  absl::MutexLock lifecycle(plan_lifecycle_mu_);
+  if (generation != 0) {
+    std::optional<uint64_t> current = ActivePlanGeneration(uuid);
+    if (!current.has_value() || *current != generation) {
+      return;  // the plan is gone, or the uuid already belongs to a newer one
+    }
+  }
+  absl::Status status =
+      kv_cache::KVCacheManagerBase::UnregisterActivePlan(uuid);
+  if (!status.ok() && !absl::IsNotFound(status)) {
+    LOG(ERROR) << "Failed to unregister settled transfer plan " << uuid << ": "
+               << status;
+  }
+}
+
 std::vector<RaidenTransferEndpoint>
 KVCacheManagerWithTransfer::get_local_endpoints() const {
   // NOTE: prefers the CONTROL port when a control server is running, because
@@ -1576,7 +1702,8 @@ void KVCacheManagerWithTransfer::StartRead(
     }
     recv_slot = staging.slot_idx;
     staged_host_blocks = std::move(staging.staged_host_blocks);
-    absl::flat_hash_map<int64_t, int64_t> local_to_host;
+    absl::flat_hash_map<kv_cache::DeviceBlockId, kv_cache::HostBlockId>
+        local_to_host;
     size_t host_block_idx = 0;
     host_block_ids.reserve(local_block_ids.size());
     for (size_t k = 0; k < local_block_ids.size(); ++k) {
@@ -1702,7 +1829,7 @@ KVCacheManagerWithTransfer::CompleteReadRaw() {
   std::vector<std::string> done_sending;
   std::vector<std::string> done_recving;
   std::vector<std::string> failed_recving;
-  std::vector<uint64_t> timed_out_plan_uuids;
+  std::vector<std::pair<uint64_t, uint64_t>> settled_plans;
   {
     absl::MutexLock lock(mu_);
     const auto now = std::chrono::steady_clock::now();
@@ -1713,7 +1840,7 @@ KVCacheManagerWithTransfer::CompleteReadRaw() {
         // never sent, so the transfer failed.
         failed_recving_.insert(entry->req_id);
         ReleaseEntrySlotLocked(entry);
-        timed_out_plan_uuids.push_back(it->first);
+        settled_plans.emplace_back(it->first, 0);
         it = send_entries_.erase(it);
       } else {
         ++it;
@@ -1724,7 +1851,7 @@ KVCacheManagerWithTransfer::CompleteReadRaw() {
       const auto& entry = it->second;
       if (entry->deadline <= now) {
         failed_recving_.insert(entry->req_id);
-        timed_out_plan_uuids.push_back(it->first);
+        settled_plans.emplace_back(it->first, 0);
         auto erase_it = it++;
         active_pool_reshard_sends_.erase(erase_it);
       } else {
@@ -1752,6 +1879,9 @@ KVCacheManagerWithTransfer::CompleteReadRaw() {
                     << entry.req_id;
           done_recving_.insert(entry.req_id);
           ReleaseRecvStagingLocked(&entry);
+          if (entry.unregister_on_settle) {
+            settled_plans.emplace_back(it->first, entry.plan_generation);
+          }
           active_recv_entries_.erase(it++);
           continue;
         }
@@ -1760,7 +1890,7 @@ KVCacheManagerWithTransfer::CompleteReadRaw() {
       if (entry.deadline <= now) {
         failed_recving_.insert(entry.req_id);
         ReleaseRecvStagingLocked(&entry);
-        timed_out_plan_uuids.push_back(it->first);
+        settled_plans.emplace_back(it->first, entry.plan_generation);
         active_recv_entries_.erase(it++);
       } else {
         ++it;
@@ -1774,13 +1904,9 @@ KVCacheManagerWithTransfer::CompleteReadRaw() {
     failed_recving_.clear();
   }
   // Unregistering drops the plan and its transport receive-progress counters
-  // (ForgetPushProgress), so a timed-out uuid is reusable.
-  for (uint64_t uuid : timed_out_plan_uuids) {
-    absl::Status status = UnregisterActivePlan(uuid);
-    if (!status.ok() && !absl::IsNotFound(status)) {
-      LOG(ERROR) << "Failed to unregister timed-out transfer plan " << uuid
-                 << ": " << status;
-    }
+  // (ForgetPushProgress), so a settled uuid is reusable.
+  for (const auto& [uuid, generation] : settled_plans) {
+    UnregisterSettledPlan(uuid, generation);
   }
   return {done_sending, done_recving, failed_recving};
 }
@@ -2753,8 +2879,11 @@ absl::Status KVCacheManagerWithTransfer::OnBlocksReceived(
   int64_t recv_slot = -1;
   std::vector<int> recv_staged;
   CopySpec h2d_copy;
-  absl::flat_hash_map<int64_t, int64_t> host_to_chip;
+  absl::flat_hash_map<kv_cache::HostBlockId, kv_cache::DeviceBlockId>
+      host_to_chip;
   bool found = false;
+  bool unregister_plan = false;
+  uint64_t plan_generation = 0;
   std::vector<int> accumulated_host_blocks;
 
   std::chrono::steady_clock::time_point start_time;
@@ -2793,6 +2922,8 @@ absl::Status KVCacheManagerWithTransfer::OnBlocksReceived(
           }
           found = true;
           recv_staged = std::move(it->second.staged_host_blocks);
+          unregister_plan = it->second.unregister_on_settle;
+          plan_generation = it->second.plan_generation;
           active_recv_entries_.erase(it);
         }
       } else {
@@ -2819,6 +2950,7 @@ absl::Status KVCacheManagerWithTransfer::OnBlocksReceived(
     done_recving_.insert(req_id);
     ReleaseStagingLocked(recv_slot, &recv_staged);
   }
+  if (unregister_plan) UnregisterSettledPlan(uuid, plan_generation);
 
   LOG(INFO) << "OnBlocksReceived (Network + H2D complete): req_id=" << req_id
             << ", uuid=" << uuid
@@ -2999,54 +3131,70 @@ absl::Status KVCacheManagerWithTransfer::OnLayerReceived(size_t layer_idx,
                                    h2d_copy.sizes, /*slot_idx=*/std::nullopt,
                                    /*layer_idx=*/layer_idx);
   if (!future_or.ok()) {
-    absl::MutexLock lock(mu_);
-    failed_recving_.insert(req_id);
-    auto it = active_recv_entries_.find(uuid);
-    if (it != active_recv_entries_.end()) {
-      ReleaseRecvStagingLocked(&it->second);
-      active_recv_entries_.erase(it);
+    bool unregister_plan = false;
+    uint64_t plan_generation = 0;
+    {
+      absl::MutexLock lock(mu_);
+      failed_recving_.insert(req_id);
+      auto it = active_recv_entries_.find(uuid);
+      if (it != active_recv_entries_.end()) {
+        ReleaseRecvStagingLocked(&it->second);
+        unregister_plan = it->second.unregister_on_settle;
+        plan_generation = it->second.plan_generation;
+        active_recv_entries_.erase(it);
+      }
     }
+    if (unregister_plan) UnregisterSettledPlan(uuid, plan_generation);
     return future_or.status();
   }
 
   auto future = future_or.value();
   future.OnReady([this, uuid, layer_idx, recv_slot, req_id,
                   metrics_collector = metrics_collector_](auto status_or) {
-    absl::MutexLock lock(mu_);
-    auto it = active_recv_entries_.find(uuid);
-    if (it == active_recv_entries_.end()) {
-      return;
-    }
-    auto& entry = it->second;
-    if (status_or.ok()) {
-      LOG(INFO) << "OnLayerReceived (H2D copy complete) layer " << layer_idx
-                << ": req_id=" << req_id
-                << ", numa=" << assigned_numa_node().value_or(-1);
-      entry.num_completed_layers++;
-      if (entry.num_completed_layers == num_layers()) {
-        // TODO: Find a way to optimize this by moving out of the mutex.
-        RecordTransferDuration(
-            DurationMs(entry.start_time, std::chrono::steady_clock::now()));
+    bool unregister_plan = false;
+    uint64_t plan_generation = 0;
+    {
+      absl::MutexLock lock(mu_);
+      auto it = active_recv_entries_.find(uuid);
+      if (it == active_recv_entries_.end()) {
+        return;
+      }
+      auto& entry = it->second;
+      if (status_or.ok()) {
+        LOG(INFO) << "OnLayerReceived (H2D copy complete) layer " << layer_idx
+                  << ": req_id=" << req_id
+                  << ", numa=" << assigned_numa_node().value_or(-1);
+        entry.num_completed_layers++;
+        if (entry.num_completed_layers == num_layers()) {
+          // TODO: Find a way to optimize this by moving out of the mutex.
+          RecordTransferDuration(
+              DurationMs(entry.start_time, std::chrono::steady_clock::now()));
 
-        if (metrics_collector) {
-          metrics_collector->RecordH2dComplete(uuid);
+          if (metrics_collector) {
+            metrics_collector->RecordH2dComplete(uuid);
+          }
+          LOG(INFO) << "All layers H2D copy complete: req_id=" << req_id;
+          if (metrics_collector) {
+            metrics_collector->RecordEnd(uuid);
+          }
+          done_recving_.insert(req_id);
+          ReleaseRecvStagingLocked(&entry);
+          unregister_plan = entry.unregister_on_settle;
+          plan_generation = entry.plan_generation;
+          active_recv_entries_.erase(uuid);
         }
-        LOG(INFO) << "All layers H2D copy complete: req_id=" << req_id;
-        if (metrics_collector) {
-          metrics_collector->RecordEnd(uuid);
-        }
-        done_recving_.insert(req_id);
+      } else {
+        LOG(ERROR) << "OnLayerReceived (H2D copy failed) layer " << layer_idx
+                   << " for req_id: " << req_id
+                   << ", error: " << status_or.status().ToString();
+        failed_recving_.insert(req_id);
         ReleaseRecvStagingLocked(&entry);
+        unregister_plan = entry.unregister_on_settle;
+        plan_generation = entry.plan_generation;
         active_recv_entries_.erase(uuid);
       }
-    } else {
-      LOG(ERROR) << "OnLayerReceived (H2D copy failed) layer " << layer_idx
-                 << " for req_id: " << req_id
-                 << ", error: " << status_or.status().ToString();
-      failed_recving_.insert(req_id);
-      ReleaseRecvStagingLocked(&entry);
-      active_recv_entries_.erase(uuid);
     }
+    if (unregister_plan) UnregisterSettledPlan(uuid, plan_generation);
   });
 
   {

--- a/tpu_sync/core/kv_cache_manager_with_transfer.h
+++ b/tpu_sync/core/kv_cache_manager_with_transfer.h
@@ -204,6 +204,10 @@ class KVCacheManagerWithTransfer : public kv_cache::KVCacheManagerBase {
   absl::Status RegisterActivePlan(
       uint64_t uuid, const ::tpu_sync::rpc::StartTransferRequest& request,
       bool is_sender) override;
+  absl::Status UnregisterActivePlan(uint64_t uuid) override;
+  // Drops the plan of a receive that has settled; a plan already gone, or
+  // a newer registration reusing the uuid, is left alone.
+  void UnregisterSettledPlan(uint64_t uuid, uint64_t generation);
 
   absl::Status RegisterRecv(uint64_t uuid, const std::string& req_id,
                             int64_t expected_block_count) override;
@@ -341,6 +345,18 @@ class KVCacheManagerWithTransfer : public kv_cache::KVCacheManagerBase {
   Slot AcquireSlotLocked();
   void ReleaseSlotLocked(int64_t slot_idx);
   struct RecvEntry;  // defined below; staging helpers take it by pointer
+  // Serializes plan registration and unregistration, so a plan is never
+  // published without its staging owner or torn down against a half-built
+  // registration.
+  absl::Mutex plan_lifecycle_mu_;
+  // Source of plan generations: the uuid names a transfer, a generation
+  // names one registration of it (the same uuid may come back, e.g. on a
+  // retry of the same transfer).
+  uint64_t plan_generation_counter_ ABSL_GUARDED_BY(plan_lifecycle_mu_) = 0;
+  // Host staging held by a plan: a sender's, or a receiver's whose
+  // destination is host memory. Released when the plan is unregistered.
+  absl::flat_hash_map<uint64_t, std::vector<int>> plan_staging_
+      ABSL_GUARDED_BY(mu_);
   // Host staging for one incoming read: exactly `num_blocks` blocks under
   // demand staging, a whole fixed slot otherwise. Returns nullopt when the
   // staging pool cannot seat the request.
@@ -384,7 +400,8 @@ class KVCacheManagerWithTransfer : public kv_cache::KVCacheManagerBase {
     std::vector<int> staged_host_blocks;
     CopySpec h2d_copy;
     std::vector<int64_t> chip_block_ids;
-    absl::flat_hash_map<int64_t, int64_t> host_to_chip;
+    absl::flat_hash_map<kv_cache::HostBlockId, kv_cache::DeviceBlockId>
+        host_to_chip;
     std::map<std::pair<size_t, size_t>, std::vector<PendingCopy>>
         pending_h2d_copies;
     std::vector<H2dIssueFuture> h2d_dispatch_futures;
@@ -399,6 +416,15 @@ class KVCacheManagerWithTransfer : public kv_cache::KVCacheManagerBase {
     std::chrono::steady_clock::time_point start_time;
     std::vector<raiden::PjRtCopyFuture> h2d_futures;
     bool is_pool_reshard = false;
+    // The plan is dropped when this receive settles: set for every
+    // demand-staged receiver plan (whose mapping would otherwise outlive its
+    // freed blocks) and when an unregister arrives while the receive is in
+    // flight (the plan stays mapped until then so late pushes resolve
+    // through its blocks).
+    bool unregister_on_settle = false;
+    // Generation of the plan this receive belongs to; settlement cleanup
+    // only touches that registration.
+    uint64_t plan_generation = 0;
     std::set<size_t> expected_pool_indices;
     std::set<size_t> started_pool_indices;
     std::set<size_t> completed_pool_indices;

--- a/tpu_sync/core/kv_cache_manager_with_transfer_pool_reshard_test.cc
+++ b/tpu_sync/core/kv_cache_manager_with_transfer_pool_reshard_test.cc
@@ -25,11 +25,14 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <tuple>
 #include <utility>
 #include <vector>
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include "absl/time/clock.h"
+#include "absl/time/time.h"
 #include "absl/status/status.h"
 #include "absl/types/span.h"
 #include "tpu_sync/core/kv_cache_manager_with_transfer.h"
@@ -43,7 +46,9 @@ namespace {
 
 using ::testing::_;
 using ::testing::Ge;
+using ::testing::Contains;
 using ::testing::IsEmpty;
+using ::tpu_sync::rpc::MEMORY_TYPE_DRAM;
 using ::tpu_sync::rpc::MEMORY_TYPE_HBM;
 using ::tpu_sync::rpc::ShardPushEntryProto;
 using ::tpu_sync::rpc::StartTransferRequest;
@@ -68,6 +73,9 @@ class TestManager : public KVCacheManagerWithTransfer {
   // that never touch the holds (validation and the no-bytes-owned sender
   // completion) may rely on it.
   void AttachPlaceholderDeviceHold() { buffer_holds_.emplace_back(); }
+  // Stages plans in per-transfer host blocks, as
+  // TPU_RAIDEN_DYNAMIC_HOST_STAGING=1 does for device-attached managers.
+  void EnableDemandStaging() { dynamic_host_staging_ = true; }
 };
 
 kv_cache::PoolSpec DensePool(std::string tag, int64_t block_stride = 128,
@@ -123,6 +131,34 @@ StartTransferRequest ValidPlan(
   entry->set_src_stride_bytes(0);
   entry->set_dst_stride_bytes(0);
   entry->set_count(1);
+  return plan;
+}
+
+// A block-addressed plan (no pool groups) that moves `src` to `dst` on one
+// shard, destined for HBM or for host memory.
+StartTransferRequest BlockPlan(int64_t uuid, const std::vector<int32_t>& src,
+                               const std::vector<int32_t>& dst,
+                               ::tpu_sync::rpc::MemoryType dst_mem_type) {
+  StartTransferRequest plan;
+  plan.set_uuid(uuid);
+  plan.set_req_id("block_plan_req_" + std::to_string(uuid));
+  plan.set_dst_mem_type(dst_mem_type);
+  plan.set_use_block_chunks(true);
+  plan.set_parallelism(1);
+  auto* schedule = &(*plan.mutable_shard_push_schedules())[0];
+  for (size_t i = 0; i < src.size(); ++i) {
+    auto* entry = schedule->add_entries();
+    entry->set_dst_peer("127.0.0.1:1");
+    entry->set_dst_shard_idx(0);
+    entry->set_src_block_id(src[i]);
+    entry->set_dst_block_id(dst[i]);
+    entry->set_src_offset_bytes(0);
+    entry->set_dst_offset_bytes(0);
+    entry->set_size_bytes(16);
+    entry->set_src_stride_bytes(0);
+    entry->set_dst_stride_bytes(0);
+    entry->set_count(1);
+  }
   return plan;
 }
 
@@ -684,6 +720,199 @@ TEST(PoolReshardRecvTest, FinishPoolReshardRecvDoesNotRecordMetricOnFailure) {
   // Simulate pool failure
   manager.FinishPoolReshardRecvPool(3002, /*pool_idx=*/0,
                                     absl::InternalError("simulated failure"));
+}
+
+
+TEST(SendDeadlineTest, ExpiredSendEntryFailsInsteadOfReportingDone) {
+  TestManager manager(/*timeout_s=*/0.05);
+  ASSERT_GT(manager.NotifyForRead("expired_send_req", 31, {0, 1}), 0);
+
+  absl::SleepFor(absl::Milliseconds(120));
+  const auto [done_sending, done_recving, failed_recving] =
+      manager.CompleteReadRaw();
+  EXPECT_THAT(done_sending, IsEmpty());
+  EXPECT_THAT(failed_recving, Contains("expired_send_req"));
+}
+
+TEST(DemandStagingTest, SenderPlanReturnsStagingOnUnregister) {
+  TestManager manager;
+  manager.EnableDemandStaging();
+  auto* pool = manager.host_block_manager();
+  const int free_before = pool->num_free_blocks();
+  ASSERT_TRUE(manager
+                  .RegisterActivePlan(21, BlockPlan(21, {0, 1}, {2, 3},
+                                                    MEMORY_TYPE_HBM),
+                                      /*is_sender=*/true)
+                  .ok());
+  EXPECT_EQ(pool->num_free_blocks(), free_before - 2);
+  EXPECT_EQ(pool->num_locked_blocks(), 2);
+  ASSERT_TRUE(manager.UnregisterActivePlan(21).ok());
+  EXPECT_EQ(pool->num_free_blocks(), free_before);
+  EXPECT_EQ(pool->num_locked_blocks(), 0);
+}
+
+TEST(DemandStagingTest, HostReceiverPlanReturnsStagingOnUnregister) {
+  TestManager manager;
+  manager.EnableDemandStaging();
+  auto* pool = manager.host_block_manager();
+  const int free_before = pool->num_free_blocks();
+  ASSERT_TRUE(manager
+                  .RegisterActivePlan(22, BlockPlan(22, {0, 1}, {2, 3},
+                                                    MEMORY_TYPE_DRAM),
+                                      /*is_sender=*/false)
+                  .ok());
+  EXPECT_EQ(pool->num_free_blocks(), free_before - 2);
+  EXPECT_EQ(pool->num_locked_blocks(), 2);
+  ASSERT_TRUE(manager.UnregisterActivePlan(22).ok());
+  EXPECT_EQ(pool->num_free_blocks(), free_before);
+  EXPECT_EQ(pool->num_locked_blocks(), 0);
+}
+
+TEST(DemandStagingTest, DuplicateSenderRegistrationKeepsOriginalStaging) {
+  TestManager manager;
+  manager.EnableDemandStaging();
+  auto* pool = manager.host_block_manager();
+  const int free_before = pool->num_free_blocks();
+  const StartTransferRequest plan =
+      BlockPlan(23, {0, 1}, {2, 3}, MEMORY_TYPE_HBM);
+  ASSERT_TRUE(manager.RegisterActivePlan(23, plan, /*is_sender=*/true).ok());
+  const int free_registered = pool->num_free_blocks();
+  EXPECT_EQ(free_registered, free_before - 2);
+
+  // The second registration is refused and must neither keep its own
+  // staging nor disturb the first plan's.
+  const absl::Status duplicate =
+      manager.RegisterActivePlan(23, plan, /*is_sender=*/true);
+  EXPECT_EQ(duplicate.code(), absl::StatusCode::kAlreadyExists)
+      << duplicate.ToString();
+  EXPECT_EQ(pool->num_free_blocks(), free_registered);
+  EXPECT_EQ(pool->num_locked_blocks(), 2);
+
+  ASSERT_TRUE(manager.UnregisterActivePlan(23).ok());
+  EXPECT_EQ(pool->num_free_blocks(), free_before);
+  EXPECT_EQ(pool->num_locked_blocks(), 0);
+}
+
+
+TEST(DemandStagingTest, UnregisteringInFlightReceiverDefersUntilItSettles) {
+  TestManager manager(/*timeout_s=*/0.05);
+  manager.EnableDemandStaging();
+  manager.AttachPlaceholderDeviceHold();
+  auto* pool = manager.host_block_manager();
+  const int free_before = pool->num_free_blocks();
+  ASSERT_TRUE(manager
+                  .RegisterActivePlan(24, BlockPlan(24, {0, 1}, {2, 3},
+                                                    MEMORY_TYPE_HBM),
+                                      /*is_sender=*/false)
+                  .ok());
+  EXPECT_EQ(pool->num_free_blocks(), free_before - 2);
+  const auto staged = manager.PlanHostBlocks(24, {2, 3});
+  ASSERT_TRUE(staged.ok()) << staged.status();
+
+  // Unregistering while the receive is in flight keeps the plan's mapping
+  // and its staging, so pushes already accepted still land in the plan's
+  // blocks ...
+  ASSERT_TRUE(manager.UnregisterActivePlan(24).ok());
+  const auto still_staged = manager.PlanHostBlocks(24, {2, 3});
+  ASSERT_TRUE(still_staged.ok()) << still_staged.status();
+  EXPECT_EQ(*still_staged, *staged);
+  EXPECT_EQ(pool->num_free_blocks(), free_before - 2);
+
+  // ... until the receive settles; here it times out. Then the plan, its
+  // staging and the receive entry go together.
+  absl::SleepFor(absl::Milliseconds(120));
+  const auto [done_sending, done_recving, failed_recving] =
+      manager.CompleteReadRaw();
+  EXPECT_THAT(failed_recving, Contains("block_plan_req_24"));
+  EXPECT_EQ(manager.PlanHostBlocks(24, {2, 3}).status().code(),
+            absl::StatusCode::kNotFound);
+  EXPECT_EQ(pool->num_free_blocks(), free_before);
+  EXPECT_EQ(pool->num_locked_blocks(), 0);
+}
+
+TEST(DemandStagingTest, PlanHostBlocksFailsClosed) {
+  TestManager manager;
+  manager.EnableDemandStaging();
+  auto* pool = manager.host_block_manager();
+  EXPECT_EQ(manager.PlanHostBlocks(25, {0}).status().code(),
+            absl::StatusCode::kNotFound);
+
+  // Occupy the identity blocks first, so the plan's host blocks provably
+  // differ from its device blocks.
+  const auto occupied = pool->Allocate(2, /*lock=*/true);
+  ASSERT_TRUE(occupied.ok());
+  ASSERT_TRUE(manager
+                  .RegisterActivePlan(25, BlockPlan(25, {0, 1}, {2, 3},
+                                                    MEMORY_TYPE_HBM),
+                                      /*is_sender=*/true)
+                  .ok());
+  const auto staged = manager.PlanHostBlocks(25, {0, 1});
+  ASSERT_TRUE(staged.ok()) << staged.status();
+  ASSERT_EQ(staged->size(), 2u);
+  EXPECT_NE(*staged, (std::vector<int64_t>{0, 1}));
+  EXPECT_TRUE(pool->IsLocked(static_cast<int>((*staged)[0])));
+  EXPECT_TRUE(pool->IsLocked(static_cast<int>((*staged)[1])));
+  // A block the plan does not stage is refused rather than passed through.
+  EXPECT_EQ(manager.PlanHostBlocks(25, {0, 7}).status().code(),
+            absl::StatusCode::kInvalidArgument);
+
+  ASSERT_TRUE(manager.UnregisterActivePlan(25).ok());
+  EXPECT_EQ(manager.PlanHostBlocks(25, {0}).status().code(),
+            absl::StatusCode::kNotFound);
+}
+
+TEST(DemandStagingTest, PlanHostBlocksIsIdentityForFixedStaging) {
+  TestManager manager;
+  ASSERT_TRUE(manager
+                  .RegisterActivePlan(26, BlockPlan(26, {0, 1}, {2, 3},
+                                                    MEMORY_TYPE_HBM),
+                                      /*is_sender=*/true)
+                  .ok());
+  const auto staged = manager.PlanHostBlocks(26, {0, 1});
+  ASSERT_TRUE(staged.ok()) << staged.status();
+  EXPECT_EQ(*staged, (std::vector<int64_t>{0, 1}));
+  // Identity covers only the blocks the plan names.
+  EXPECT_EQ(manager.PlanHostBlocks(26, {7}).status().code(),
+            absl::StatusCode::kInvalidArgument);
+  ASSERT_TRUE(manager.UnregisterActivePlan(26).ok());
+}
+
+TEST(DemandStagingTest, PlanHostBlocksRejectsBlocksOfAnEmptyPlan) {
+  TestManager manager;
+  manager.EnableDemandStaging();
+  ASSERT_TRUE(manager
+                  .RegisterActivePlan(28, BlockPlan(28, {}, {},
+                                                    MEMORY_TYPE_HBM),
+                                      /*is_sender=*/true)
+                  .ok());
+  EXPECT_EQ(manager.PlanHostBlocks(28, {0}).status().code(),
+            absl::StatusCode::kInvalidArgument);
+  ASSERT_TRUE(manager.UnregisterActivePlan(28).ok());
+}
+
+TEST(DemandStagingTest, DemandStagedReceiverPlanUnregistersWhenItSettles) {
+  TestManager manager(/*timeout_s=*/0.05);
+  manager.EnableDemandStaging();
+  manager.AttachPlaceholderDeviceHold();
+  auto* pool = manager.host_block_manager();
+  const int free_before = pool->num_free_blocks();
+  ASSERT_TRUE(manager
+                  .RegisterActivePlan(27, BlockPlan(27, {0, 1}, {2, 3},
+                                                    MEMORY_TYPE_HBM),
+                                      /*is_sender=*/false)
+                  .ok());
+  ASSERT_TRUE(manager.PlanHostBlocks(27, {2, 3}).ok());
+
+  // Nobody unregisters; the plan still goes when the receive settles (here
+  // by timeout), leaving neither a stale mapping nor held blocks behind.
+  absl::SleepFor(absl::Milliseconds(120));
+  const auto [done_sending, done_recving, failed_recving] =
+      manager.CompleteReadRaw();
+  EXPECT_THAT(failed_recving, Contains("block_plan_req_27"));
+  EXPECT_EQ(manager.PlanHostBlocks(27, {2, 3}).status().code(),
+            absl::StatusCode::kNotFound);
+  EXPECT_EQ(pool->num_free_blocks(), free_before);
+  EXPECT_EQ(pool->num_locked_blocks(), 0);
 }
 
 }  // namespace

--- a/tpu_sync/frameworks/torch/kv_cache_manager.h
+++ b/tpu_sync/frameworks/torch/kv_cache_manager.h
@@ -238,6 +238,11 @@ class KVCacheManager {
     return torch_manager_->UnregisterActivePlan(uuid);
   }
 
+  absl::StatusOr<std::vector<int64_t>> PlanHostBlocks(
+      uint64_t uuid, const std::vector<int64_t>& block_ids) {
+    return torch_manager_->PlanHostBlocks(uuid, block_ids);
+  }
+
   absl::Status RegisterRecv(uint64_t uuid, const std::string& req_id,
                             int64_t expected_block_count) {
     return torch_manager_->RegisterRecv(uuid, req_id, expected_block_count);

--- a/tpu_sync/frameworks/torch/tpu_raiden_host_module.cc
+++ b/tpu_sync/frameworks/torch/tpu_raiden_host_module.cc
@@ -242,7 +242,11 @@ NB_MODULE(_tpu_raiden_host, m) {
       .def(
           "unregister_active_plan",
           [](HostKVCacheManager& self, uint64_t uuid) {
-            ThrowIfError(self.UnregisterActivePlan(uuid),
+            absl::Status status = self.UnregisterActivePlan(uuid);
+            // A plan that already settled is gone; unregistering it again is
+            // a no-op rather than an error.
+            if (absl::IsNotFound(status)) return;
+            ThrowIfError(status,
                          "KVCacheManager unregister_active_plan failed");
           },
           nb::arg("uuid"))

--- a/tpu_sync/frameworks/torch/tpu_raiden_torch_module.cc
+++ b/tpu_sync/frameworks/torch/tpu_raiden_torch_module.cc
@@ -272,6 +272,9 @@ NB_MODULE(_tpu_raiden_torch, m) {
           "unregister_active_plan",
           [](KVCacheManager& self, uint64_t uuid) {
             absl::Status status = self.UnregisterActivePlan(uuid);
+            // A plan that already settled is gone; unregistering it again is
+            // a no-op rather than an error.
+            if (absl::IsNotFound(status)) return;
             if (!status.ok()) {
               throw std::runtime_error(
                   "KVCacheManager unregister_active_plan failed: " +
@@ -279,6 +282,17 @@ NB_MODULE(_tpu_raiden_torch, m) {
             }
           },
           nb::arg("uuid"))
+      .def(
+          "plan_host_blocks",
+          [](KVCacheManager& self, uint64_t uuid,
+             const std::vector<int64_t>& block_ids) {
+            auto blocks = self.PlanHostBlocks(uuid, block_ids);
+            if (!blocks.ok()) {
+              throw std::runtime_error(std::string(blocks.status().message()));
+            }
+            return *std::move(blocks);
+          },
+          nb::arg("uuid"), nb::arg("block_ids"))
       .def(
           "push_registered_plan",
           [](KVCacheManager& self, uint64_t uuid, const std::string& peer,

--- a/tpu_sync/kv_cache/kv_cache_manager_base.cc
+++ b/tpu_sync/kv_cache/kv_cache_manager_base.cc
@@ -35,6 +35,8 @@
 
 #include "absl/base/thread_annotations.h"
 #include "absl/cleanup/cleanup.h"
+#include "absl/container/flat_hash_map.h"
+#include "absl/container/flat_hash_set.h"
 #include "absl/log/log.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
@@ -2228,6 +2230,52 @@ absl::Status KVCacheManagerBase::PushKVCacheResharded(
 absl::Status KVCacheManagerBase::RegisterActivePlan(
     uint64_t uuid, const ::tpu_sync::rpc::StartTransferRequest& request,
     bool is_sender) {
+  return RegisterActivePlan(uuid, request, is_sender, {});
+}
+
+absl::StatusOr<std::vector<HostBlockId>> KVCacheManagerBase::PlanHostBlocks(
+    uint64_t uuid, const std::vector<DeviceBlockId>& block_ids) const {
+  std::shared_ptr<const RegisteredPlan> plan;
+  {
+    absl::MutexLock l(plans_mu_);
+    auto it = active_plans_.find(uuid);
+    if (it != active_plans_.end()) plan = it->second;
+  }
+  if (plan == nullptr) {
+    return absl::NotFoundError(
+        absl::StrCat("no active transfer plan with uuid ", uuid));
+  }
+  if (plan->request.pool_groups_size() > 0) {
+    return absl::FailedPreconditionError(absl::StrCat(
+        "transfer plan ", uuid, " is pool-addressed; its bytes are staged at "
+        "pool offsets, not per-block host blocks"));
+  }
+  std::vector<int64_t> out;
+  out.reserve(block_ids.size());
+  for (int64_t id : block_ids) {
+    if (!plan->staged_device_blocks.contains(id)) {
+      return absl::InvalidArgumentError(absl::StrCat(
+          "block ", id, " is not staged by transfer plan ", uuid));
+    }
+    if (plan->host_block_of.empty()) {
+      out.push_back(id);
+      continue;
+    }
+    auto it = plan->host_block_of.find(id);
+    if (it == plan->host_block_of.end()) {
+      return absl::InvalidArgumentError(absl::StrCat(
+          "block ", id, " is not staged by transfer plan ", uuid));
+    }
+    out.push_back(it->second);
+  }
+  return out;
+}
+
+absl::Status KVCacheManagerBase::RegisterActivePlan(
+    uint64_t uuid, const ::tpu_sync::rpc::StartTransferRequest& request,
+    bool is_sender,
+    absl::flat_hash_map<DeviceBlockId, HostBlockId> host_block_of,
+    uint64_t generation) {
   // Structural contract for pool-addressed plans. Pool selection is request
   // data resolved by the controller; raiden validates consistency (indices
   // resolve against this manager's pool table, explicit or implicit) and
@@ -2280,10 +2328,20 @@ absl::Status KVCacheManagerBase::RegisterActivePlan(
       }
     }
   }
+  absl::flat_hash_set<int64_t> staged_device_blocks;
+  if (request.pool_groups_size() == 0) {
+    for (const auto& [src_shard, schedule] : request.shard_push_schedules()) {
+      for (const auto& entry : schedule.entries()) {
+        staged_device_blocks.insert(is_sender ? entry.src_block_id()
+                                              : entry.dst_block_id());
+      }
+    }
+  }
   absl::MutexLock l(plans_mu_);
   if (auto [it, inserted] = active_plans_.try_emplace(
-          uuid, std::make_shared<const RegisteredPlan>(
-                    RegisteredPlan{request, is_sender}));
+          uuid, std::make_shared<const RegisteredPlan>(RegisteredPlan{
+                    request, is_sender, std::move(host_block_of),
+                    std::move(staged_device_blocks), generation}));
       !inserted) {
     return absl::AlreadyExistsError(
         absl::StrCat("Plan with UUID ", uuid, " is already registered!"));
@@ -2421,7 +2479,18 @@ KVCacheManagerBase::GetBlockChunks(size_t layer_idx, size_t shard_idx,
 
   for (int64_t block_id : block_ids) {
     if (accumulated_bytes >= total_bytes) break;
-    size_t block_start_byte = static_cast<size_t>(block_id) * block_size_bytes;
+    // The wire names device blocks; the bytes live wherever this side staged
+    // them, which is the block's own id unless the plan says otherwise.
+    int64_t host_block = block_id;
+    if (!plan_snapshot->host_block_of.empty()) {
+      auto hb = plan_snapshot->host_block_of.find(block_id);
+      if (hb == plan_snapshot->host_block_of.end()) {
+        return {};
+      }
+      host_block = hb->second;
+    }
+    size_t block_start_byte =
+        static_cast<size_t>(host_block) * block_size_bytes;
     std::vector<tpu_raiden::transport::BlockChunk> block_resolved_chunks;
 
     if (is_sender) {

--- a/tpu_sync/kv_cache/kv_cache_manager_base.h
+++ b/tpu_sync/kv_cache/kv_cache_manager_base.h
@@ -29,6 +29,7 @@
 
 #include "absl/base/thread_annotations.h"
 #include "absl/container/flat_hash_map.h"
+#include "absl/container/flat_hash_set.h"
 #include "absl/functional/any_invocable.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
@@ -107,6 +108,11 @@ struct KVCacheHostSpan {
 
 using ::tpu_raiden::HostBufferAllocation;
 using ::tpu_raiden::HostBufferAllocator;
+
+// One integer alias per block-id space: a device (chip) KV block id, and a
+// host staging/mirror block id. Documentation only; both are int64_t.
+using DeviceBlockId = int64_t;
+using HostBlockId = int64_t;
 
 class KVCacheManagerBase : public tpu_raiden::RaidenManagerBase {
  public:
@@ -368,8 +374,40 @@ class KVCacheManagerBase : public tpu_raiden::RaidenManagerBase {
   virtual absl::Status RegisterActivePlan(
       uint64_t uuid, const ::tpu_sync::rpc::StartTransferRequest& request,
       bool is_sender);
+  // Same, with the plan's device blocks staged in explicitly chosen host
+  // blocks instead of at their own ids: `host_block_of` maps each device
+  // block id the plan names on this side to the host block staging it.
+  // `generation` identifies this registration among transfers that reuse
+  // the same uuid (e.g. a retry); see RegisteredPlan::generation.
+  absl::Status RegisterActivePlan(
+      uint64_t uuid, const ::tpu_sync::rpc::StartTransferRequest& request,
+      bool is_sender,
+      absl::flat_hash_map<DeviceBlockId, HostBlockId> host_block_of,
+      uint64_t generation = 0);
 
   virtual absl::Status UnregisterActivePlan(uint64_t uuid);
+
+  // Whether a transfer plan is currently registered under `uuid`.
+  bool HasActivePlan(uint64_t uuid) const {
+    absl::MutexLock l(plans_mu_);
+    return active_plans_.contains(uuid);
+  }
+
+  // The generation of the plan registered under `uuid`, if any.
+  std::optional<uint64_t> ActivePlanGeneration(uint64_t uuid) const {
+    absl::MutexLock l(plans_mu_);
+    auto it = active_plans_.find(uuid);
+    if (it == active_plans_.end()) return std::nullopt;
+    return it->second->generation;
+  }
+
+  // Host blocks staging `block_ids` under plan `uuid`: the ids themselves
+  // when the plan stages blocks at their own ids, otherwise the blocks the
+  // plan allocated for them. NotFound for an unknown plan; InvalidArgument
+  // for a block the plan's schedules do not name on its side;
+  // FailedPrecondition for a pool-addressed plan.
+  absl::StatusOr<std::vector<HostBlockId>> PlanHostBlocks(
+      uint64_t uuid, const std::vector<DeviceBlockId>& block_ids) const;
 
   virtual absl::Status RegisterRecv(uint64_t uuid, const std::string& req_id,
                                     int64_t expected_block_count) {
@@ -541,6 +579,19 @@ class KVCacheManagerBase : public tpu_raiden::RaidenManagerBase {
   struct RegisteredPlan {
     ::tpu_sync::rpc::StartTransferRequest request;
     bool is_sender = false;
+    // Host block holding each device block the plan names on this side
+    // (src blocks for a sender, dst blocks for a receiver). Empty means the
+    // host mirror is addressed by device block id.
+    absl::flat_hash_map<DeviceBlockId, HostBlockId> host_block_of;
+    // Device blocks the plan's schedules name on this side; the set
+    // PlanHostBlocks() answers for.
+    absl::flat_hash_set<int64_t> staged_device_blocks;
+    // Extension of the uuid for when the same uuid names more than one
+    // transfer over time (e.g. a retry of the same transfer): each
+    // registration gets its own generation, so cleanup queued for an old
+    // registration cannot touch a newer one under the same uuid. 0 when
+    // the caller keeps no generations; cleanup then matches by uuid alone.
+    uint64_t generation = 0;
   };
   // Plans are stored behind shared_ptr so the per-push readers
   // (GetBlockChunks / GetPoolPushProgressSpec) snapshot with a refcount bump


### PR DESCRIPTION
## TL;DR

- Resharding no longer needs a host mirror of the whole device KV pool:
  each plan stages its device blocks in host blocks allocated for the plan.
- Measured on an 8→4 reshard (Qwen3-1.7B): host staging **halved** (whole
  device pool mirrored → 512-block pool) at **equal accuracy and throughput**,
  zero failed transfers. Expected on gpt-oss-120b TP8 for the same load as
  #722: **452 GiB → ~2.3 GiB per 8-rank host**. Wire protocol unchanged.
- Stacked on #722 (`TPU_RAIDEN_DYNAMIC_HOST_STAGING=1`); off by default.

## What changes

Resharding resolved every block on the wire by identity into the host mirror:
a sender staged each device block into the host block of the same id, and a
receiver landed each incoming block at its destination id and uploaded from
there. That only works when the host mirror spans the whole device block
space, so both sides of a reshard pinned a host copy of their entire device KV
pool.

| piece | change |
|---|---|
| `RegisteredPlan` | gains `host_block_of`: device block → host block for the blocks the plan names on this side |
| `GetBlockChunks` (plan branch) | resolves the wire's device block through the map; this was the single identity point for both roles |
| `RegisterActivePlan` (receiver) | allocates host blocks for the plan's destination blocks, builds the upload map from them, frees them when the receive completes |
| `RegisterActivePlan` (sender) | allocates host blocks for the plan's source blocks; freed by `UnregisterActivePlan` |
| `plan_host_blocks(uuid, block_ids)` | new API: where a sender should copy its device blocks before pushing (identity when the plan has no map) |

Pool-addressed plans keep their existing addressing.

## Validation

*Build:* torch wheel via `ci/build_wheel.sh`; the new API is present in all
three ABI extensions.

*End to end:* 8→4 reshard — prefill TP8 → decode TP8 with attention TP4 × DP2,
dense Qwen3-1.7B on v7x, 128-token pages, context length 8192. Same image,
wheels and load in every arm; the only differences are the flag and the host
pool size. Host staging per rank is read from the engine start-up line
(`max_blocks × num_slots` blocks). Every arm below runs on a build that also
carries the multi-sender completion fix for pushed transfers (*"Complete a pushed block array only after every declared sender lands"*, separate PR) — without
it the asymmetric path returns wrong output in every configuration, on or off.

**Correctness** (greedy probe: 3 prompts × 5 sequential repeats + 8 identical
concurrent requests; 200-question few-shot gsm8k):

| arm | host staging per rank | probe | gsm8k acc / invalid | failed transfers |
|---|---|---|---|---|
| symmetric TP8→TP8, no reshard (reference) | ordinary sizing | 5/5 and 8/8 identical | 0.675 / 0.000 | 0 |
| flag off (host mirror of the whole device pool) | 1025 blocks = 1.8 GB prefill rank, 3.5 GB decode rank | 5/5 sane, 8/8 identical, equal to the reference | 0.690 / 0.005 | 0 |
| **flag on, 512-block pool** | **half the device pool**: 0.9 GB prefill rank, 1.8 GB decode rank | 5/5 sane, 8/8 identical, equal to the reference | **0.685 / 0.000** | 0 |

**Throughput** (`bench_serving`, 64 × 512-token requests, 64-way, req/s · mean TTFT · mean ITL):

| arm | run 1 | run 2 |
|---|---|---|
| flag off | 12.10 · 1187 ms · 28.2 ms | 12.82 · 1225 ms · 27.0 ms |
| **flag on, 512-block pool** | 13.03 · 1571 ms · 23.3 ms | 12.39 · 1208 ms · 26.8 ms |

One probe prompt alternates between two sane continuations across its 5 repeats
in both reshard arms (not in the symmetric reference); same with and without
this PR. gsm8k second runs: 0.670 / 0.000 off, 0.665 / 0.000 on.

- Memory: across the two 8-rank hosts, 42 GB of pinned host mirror off vs
  21 GB on for this load, and the on-side figure is set by the pool size, not
  by the model. On gpt-oss-120b TP8 the mirror is 56.5 GiB per rank (452 GiB
  per host); the same 64 in-flight requests need about 2.3 GiB per host
  (projected from the page arithmetic in #722).

Engine lines (one per instance; identical across ranks):

```
off: RaidenKVManager rank0 engine up | ... max_blocks=1025 num_slots=1
on:  RaidenKVManager rank0 engine up | ... max_blocks=64   num_slots=8
```
