### PR TITLE
Add the LLVM apt source only when the image lacks it

### DIFF
--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -1,18 +1,4 @@
 #!/bin/bash
-
-# Copyright 2026 Google LLC.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 # Builds the tpu_raiden wheel hermetically inside the ml-build container
 # (glibc 2.35, matching the TPU runtime), mirroring torch_tpu/ci/build_wheel.sh.
 #

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -90,10 +90,14 @@ export DEBIAN_FRONTEND=noninteractive
 apt-get update -qq
 apt-get install -y -qq wget gnupg ca-certificates patchelf patch >/dev/null
 # Add the LLVM jammy-18 apt repo manually (the container's add-apt-repository is
-# broken: python apt_pkg is missing for python3.12).
-wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor -o /usr/share/keyrings/llvm.gpg
-echo "deb [signed-by=/usr/share/keyrings/llvm.gpg] http://apt.llvm.org/jammy/ llvm-toolchain-jammy-18 main" \
-  > /etc/apt/sources.list.d/llvm18.list
+# broken: python apt_pkg is missing for python3.12) unless the image already
+# carries it: apt refuses to read its sources when the same suite is listed
+# twice under different keyrings.
+if ! grep -rqs 'apt.llvm.org/jammy/ llvm-toolchain-jammy-18' /etc/apt/sources.list /etc/apt/sources.list.d/; then
+  wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor -o /usr/share/keyrings/llvm.gpg
+  echo "deb [signed-by=/usr/share/keyrings/llvm.gpg] http://apt.llvm.org/jammy/ llvm-toolchain-jammy-18 main" \
+    > /etc/apt/sources.list.d/llvm18.list
+fi
 apt-get update -qq
 # clang ships no standard library of its own: it compiles against the newest
 # GCC installation present. The container carries only libstdc++ 11, which


### PR DESCRIPTION
Add only missing apt source so it doesn't conflict with ones torch_tpu already registers.

Validated: torch_tpu ci/build_raiden_wheel.sh builds green