### PR TITLE
Add DMA-mapped PyTorch KV cache offloader

### DIFF
--- a/ci/wheel/BUILD.bazel
+++ b/ci/wheel/BUILD.bazel
@@ -98,6 +98,7 @@ JAX_DEPS = [
 TORCH_DEPS = [
     "//tpu_sync/frameworks/torch:_tpu_raiden_torch",
     "//tpu_sync/api/torch:kv_cache_manager_torch_py",
+    "//tpu_sync/api/torch:kv_cache_offloader_py",
     "//tpu_sync/api/torch:reshard_client",
     "//tpu_sync/api/torch:reshard_store",
     "//tpu_sync/api/torch:weight_synchronizer_torch_py",

--- a/tpu_sync/api/torch/BUILD
+++ b/tpu_sync/api/torch/BUILD
@@ -55,6 +55,23 @@ py_library(
 )
 
 py_library(
+    name = "kv_cache_offloader_py",
+    srcs = ["kv_cache_offloader.py"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":torch_abi",
+        ":torch_tpu_common_loader",
+        "//tpu_sync/frameworks/torch:_tpu_raiden_torch",
+    ],
+)
+
+py_test(
+    name = "kv_cache_offloader_test",
+    srcs = ["kv_cache_offloader_test.py"],
+    deps = [":kv_cache_offloader_py"],
+)
+
+py_library(
     name = "kv_cache_manager_host_py",
     srcs = ["kv_cache_manager.py"],
     visibility = ["//visibility:public"],

--- a/tpu_sync/api/torch/kv_cache_offloader.py
+++ b/tpu_sync/api/torch/kv_cache_offloader.py
@@ -1,0 +1,106 @@
+# Copyright 2026 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""PyTorch KV cache offloader backed by an externally managed shm pool."""
+
+from typing import Any, Sequence
+
+_TORCH_IMPL = None
+
+
+def _torch_impl():
+  """Loads the consolidated Torch extension after the torch_tpu runtime."""
+  global _TORCH_IMPL
+  if _TORCH_IMPL is None:
+    # pylint: disable=g-import-not-at-top
+    from tpu_sync.api.torch import torch_abi
+    from tpu_sync.api.torch import torch_tpu_common_loader
+
+    torch_tpu_common_loader.load_torch_tpu_common()
+    _TORCH_IMPL = torch_abi.load_extension(
+        "tpu_sync.frameworks.torch",
+        "_tpu_raiden_torch",
+    )
+    # pylint: enable=g-import-not-at-top
+  return _TORCH_IMPL
+
+
+class KVCacheOffloader:
+  """Moves KV pages between TPU buffers and complete host object views.
+
+  Each same-sized TPU physical buffer is treated as a raw byte array split
+  into ``page_nbytes`` pages; logical tensor dimensions are not interpreted.
+  Host-pool allocation and object-view creation belong to the external
+  SharedMemoryPool. This wrapper only forwards the caller's existing mapping
+  address for one whole-pool DMA registration and forwards complete object
+  tensor views to the native copy engine. The pool must provide mutually
+  disjoint object-tensor storage for all active copies.
+  """
+
+  def __init__(
+      self,
+      kv_cache_tensors: Sequence[Any],
+      page_nbytes: int,
+  ) -> None:
+    self._impl = _torch_impl().KVCacheOffloader(
+        list(kv_cache_tensors), page_nbytes
+    )
+
+  def map_shared_memory(
+      self, mapped_address: int, pool_size_bytes: int
+  ) -> None:
+    """Registers an existing whole-pool mapping for TPU DMA.
+
+    The external pool owner must keep this process-local virtual address
+    mapped and page-locked until ``unmap_shared_memory`` succeeds.
+    """
+    self._impl.map_shared_memory(mapped_address, pool_size_bytes)
+
+  def unmap_shared_memory(self) -> None:
+    """Drains submitted copies and releases the whole-pool registration."""
+    self._impl.unmap_shared_memory()
+
+  def h2d(
+      self,
+      block_ids: Sequence[int],
+      object_tensors: Sequence[Any],
+      rank_id: int,
+  ) -> Any:
+    """Starts host-to-device copies from complete object tensor views."""
+    return self._impl.h2d(list(block_ids), list(object_tensors), rank_id)
+
+  def d2h(
+      self,
+      block_ids: Sequence[int],
+      object_tensors: Sequence[Any],
+      rank_id: int,
+  ) -> Any:
+    """Starts device-to-host copies into complete object tensor views."""
+    return self._impl.d2h(list(block_ids), list(object_tensors), rank_id)
+
+  @property
+  def num_layers(self) -> int:
+    return self._impl.num_layers
+
+  @property
+  def num_blocks(self) -> int:
+    return self._impl.num_blocks
+
+  @property
+  def page_nbytes(self) -> int:
+    return self._impl.page_nbytes
+
+  @property
+  def is_shared_memory_mapped(self) -> bool:
+    return self._impl.is_shared_memory_mapped

--- a/tpu_sync/api/torch/kv_cache_offloader_test.py
+++ b/tpu_sync/api/torch/kv_cache_offloader_test.py
@@ -1,0 +1,102 @@
+# Copyright 2026 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Contract tests for the thin PyTorch KV cache offloader wrapper."""
+
+import unittest
+
+from tpu_sync.api.torch import kv_cache_offloader
+
+
+class _FakeNativeOffloader:
+
+  def __init__(self, kv_cache_tensors, page_nbytes):
+    self.calls = [("init", kv_cache_tensors, page_nbytes)]
+    self.num_layers = len(kv_cache_tensors)
+    self.num_blocks = 13
+    self.page_nbytes = page_nbytes
+    self.is_shared_memory_mapped = False
+
+  def map_shared_memory(self, mapped_address, pool_size_bytes):
+    self.calls.append(("map", mapped_address, pool_size_bytes))
+    self.is_shared_memory_mapped = True
+
+  def unmap_shared_memory(self):
+    self.calls.append(("unmap",))
+    self.is_shared_memory_mapped = False
+
+  def h2d(self, block_ids, object_tensors, rank_id):
+    self.calls.append(("h2d", block_ids, object_tensors, rank_id))
+    return "h2d-future"
+
+  def d2h(self, block_ids, object_tensors, rank_id):
+    self.calls.append(("d2h", block_ids, object_tensors, rank_id))
+    return "d2h-future"
+
+
+class _FakeExtension:
+  KVCacheOffloader = _FakeNativeOffloader
+
+
+class KVCacheOffloaderWrapperTest(unittest.TestCase):
+
+  def setUp(self):
+    super().setUp()
+    self._old_impl = kv_cache_offloader._TORCH_IMPL  # pylint: disable=protected-access
+    kv_cache_offloader._TORCH_IMPL = _FakeExtension  # pylint: disable=protected-access
+
+  def tearDown(self):
+    kv_cache_offloader._TORCH_IMPL = self._old_impl  # pylint: disable=protected-access
+    super().tearDown()
+
+  def test_forwards_full_object_views_and_mapping_contract(self):
+    device_tensors = [object(), object()]
+    object_tensors = [object(), object()]
+    offloader = kv_cache_offloader.KVCacheOffloader(
+        (tensor for tensor in device_tensors), page_nbytes=4096
+    )
+
+    offloader.map_shared_memory(mapped_address=0x40000000, pool_size_bytes=8192)
+    self.assertTrue(offloader.is_shared_memory_mapped)
+    self.assertEqual(
+        offloader.h2d((3, 5), (tensor for tensor in object_tensors), rank_id=1),
+        "h2d-future",
+    )
+    self.assertEqual(
+        offloader.d2h([3, 5], object_tensors, rank_id=0), "d2h-future"
+    )
+    offloader.unmap_shared_memory()
+
+    self.assertEqual(
+        offloader._impl.calls,  # pylint: disable=protected-access
+        [
+            ("init", device_tensors, 4096),
+            ("map", 0x40000000, 8192),
+            ("h2d", [3, 5], object_tensors, 1),
+            ("d2h", [3, 5], object_tensors, 0),
+            ("unmap",),
+        ],
+    )
+    self.assertFalse(offloader.is_shared_memory_mapped)
+
+  def test_exposes_geometry(self):
+    offloader = kv_cache_offloader.KVCacheOffloader([object()], 4096)
+
+    self.assertEqual(offloader.num_layers, 1)
+    self.assertEqual(offloader.num_blocks, 13)
+    self.assertEqual(offloader.page_nbytes, 4096)
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/tpu_sync/frameworks/torch/BUILD
+++ b/tpu_sync/frameworks/torch/BUILD
@@ -211,6 +211,7 @@ nanobind_extension(
     tags = ["nobuilder"],
     visibility = ["//visibility:public"],
     deps = [
+        ":kv_cache_offloader",
         ":kv_cache_manager_torch",
         ":pool_layout_nanobind",
         ":torch_nanobind_utils",
@@ -501,6 +502,73 @@ cc_test(
         ":torch_raw_transfer_torch_mock",
         ":torch_tpu_utils_mock",
         "@torch_tpu//shims/torch",
+        "@torch_tpu//shims/torch:torch_headers",
+        "@xla//xla/pjrt:pjrt_client",
+        "@xla//xla/pjrt/plugin/xla_cpu:xla_cpu_pjrt_client",
+        "@xla//xla/tsl/platform:statusor",
+        "@xla//xla/tsl/platform:test",
+        "@xla//xla/tsl/platform:test_main",
+    ],
+)
+
+cc_library(
+    name = "kv_cache_offloader",
+    srcs = ["kv_cache_offloader.cc"],
+    hdrs = ["kv_cache_offloader.h"],
+    copts = [
+        "-std=c++20",
+        "-fexceptions",
+        "-march=x86-64-v2",
+    ],
+    features = ["-use_header_modules"],
+    deps = [
+        ":torch_tpu_utils",
+        "//tpu_sync/core:raw_transfer_core",
+        "@com_google_absl//absl/log",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
+        "@torch_tpu//shims/torch:aten_headers",
+        "@xla//xla/pjrt:pjrt_client",
+    ],
+)
+
+cc_library(
+    name = "kv_cache_offloader_mock",
+    srcs = ["kv_cache_offloader.cc"],
+    hdrs = ["kv_cache_offloader.h"],
+    copts = [
+        "-std=c++20",
+        "-fexceptions",
+        "-march=x86-64-v2",
+    ],
+    features = ["-use_header_modules"],
+    deps = [
+        ":torch_tpu_utils_mock",
+        "//tpu_sync/core:raw_transfer_core",
+        "@com_google_absl//absl/log",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
+        "@torch_tpu//shims/torch:aten_headers",
+        "@xla//xla/pjrt:pjrt_client",
+    ],
+)
+
+cc_test(
+    name = "kv_cache_offloader_test",
+    srcs = ["kv_cache_offloader_test.cc"],
+    copts = [
+        "-std=c++20",
+        "-fexceptions",
+    ],
+    features = ["-use_header_modules"],
+    deps = [
+        ":kv_cache_offloader_mock",
+        ":torch_tpu_utils_mock",
+        "@com_google_absl//absl/status",
+        "@torch_tpu//shims/torch",
+        "@torch_tpu//shims/torch:aten_headers",
         "@torch_tpu//shims/torch:torch_headers",
         "@xla//xla/pjrt:pjrt_client",
         "@xla//xla/pjrt/plugin/xla_cpu:xla_cpu_pjrt_client",

--- a/tpu_sync/frameworks/torch/kv_cache_offloader.cc
+++ b/tpu_sync/frameworks/torch/kv_cache_offloader.cc
@@ -1,0 +1,571 @@
+// Copyright 2026 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "tpu_sync/frameworks/torch/kv_cache_offloader.h"
+
+#include <errno.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string_view>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include "ATen/core/TensorBody.h"
+#include "absl/log/log.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/str_cat.h"
+#include "tpu_sync/core/raw_transfer_core.h"
+#include "tpu_sync/frameworks/torch/torch_tpu_utils.h"
+#include "xla/pjrt/pjrt_client.h"
+
+namespace tpu_raiden::torch {
+namespace {
+
+absl::Status FirstError(absl::Status first, const absl::Status& next) {
+  return first.ok() ? next : first;
+}
+
+absl::Status PosixError(const char* operation, std::string_view guidance = {}) {
+  const int saved_errno = errno;
+  absl::Status status = absl::InternalError(
+      absl::StrCat(operation, " failed: ", std::strerror(saved_errno),
+                   guidance.empty() ? "" : absl::StrCat("; ", guidance)));
+  status.SetPayload(offloader_internal::kPosixErrorPayloadUrl,
+                    absl::Cord(operation));
+  return status;
+}
+
+absl::StatusOr<size_t> CheckedMultiply(size_t lhs, size_t rhs,
+                                       std::string_view context) {
+  if (rhs != 0 && lhs > std::numeric_limits<size_t>::max() / rhs) {
+    return absl::OutOfRangeError(absl::StrCat(context, " overflows size_t"));
+  }
+  return lhs * rhs;
+}
+
+absl::StatusOr<size_t> CheckedAdd(size_t lhs, size_t rhs,
+                                  std::string_view context) {
+  if (lhs > std::numeric_limits<size_t>::max() - rhs) {
+    return absl::OutOfRangeError(absl::StrCat(context, " overflows size_t"));
+  }
+  return lhs + rhs;
+}
+
+int64_t CheckedTransferValue(size_t value, std::string_view context) {
+  if (value > static_cast<size_t>(std::numeric_limits<int64_t>::max())) {
+    throw std::overflow_error(
+        absl::StrCat(context, " does not fit in int64_t"));
+  }
+  return static_cast<int64_t>(value);
+}
+
+std::shared_ptr<offloader_internal::OffloaderPlatform>
+CreateDefaultOffloaderPlatform(xla::PjRtClient* client) {
+  assert(client != nullptr &&
+         "prepared device state must provide a non-null PJRT client");
+  auto platform = std::make_shared<offloader_internal::OffloaderPlatform>();
+  platform->page_size = []() -> absl::StatusOr<size_t> {
+    const long value = sysconf(_SC_PAGESIZE);
+    if (value <= 0) return PosixError("sysconf(_SC_PAGESIZE)");
+    return static_cast<size_t>(value);
+  };
+  platform->dma_map = [client](void* address, size_t size_bytes) {
+    return client->DmaMap(address, size_bytes);
+  };
+  platform->dma_unmap = [client](void* address) {
+    return client->DmaUnmap(address);
+  };
+  return platform;
+}
+
+}  // namespace
+
+struct KVCacheOffloader::DeviceState {
+  struct Layer {
+    at::Tensor tensor;
+    std::optional<torch_tpu::DeviceBufferRef> ref;
+    raiden::BufferHoldAndAlias buffer;
+  };
+
+  size_t num_layers = 0;
+  size_t num_blocks = 0;
+  size_t page_nbytes = 0;
+  xla::PjRtClient* client = nullptr;
+  std::vector<Layer> layers;
+};
+
+std::shared_ptr<KVCacheOffloader::DeviceState>
+KVCacheOffloader::PrepareDeviceState(
+    const std::vector<at::Tensor>& kv_cache_tensors, size_t page_nbytes) {
+  if (kv_cache_tensors.empty()) {
+    throw std::invalid_argument("kv_cache_tensors must not be empty");
+  }
+  if (page_nbytes == 0) {
+    throw std::invalid_argument("page_nbytes must be greater than zero");
+  }
+  (void)CheckedTransferValue(page_nbytes, "page_nbytes");
+  (void)CheckedTransferValue(kv_cache_tensors.size(), "num_layers");
+
+  auto state = std::make_shared<DeviceState>();
+  state->num_layers = kv_cache_tensors.size();
+  state->page_nbytes = page_nbytes;
+  state->layers.reserve(state->num_layers);
+
+  xla::PjRtClient* expected_client = nullptr;
+  int expected_global_device_id = -1;
+  size_t expected_physical_size = 0;
+  for (size_t layer_id = 0; layer_id < state->num_layers; ++layer_id) {
+    const at::Tensor& tensor = kv_cache_tensors[layer_id];
+    // KV cache offloading intentionally operates on the model's live buffer.
+    UnpackedTensor unpacked =
+        UnpackTorchTensor(tensor, /*unsafe_skip_buffer_lock=*/true);
+    if (unpacked.buffer.buffer == nullptr ||
+        unpacked.buffer.buffer->client() == nullptr ||
+        unpacked.buffer.device == nullptr) {
+      throw std::invalid_argument(
+          absl::StrCat("kv_cache_tensors[", layer_id,
+                       "] resolved to a null PJRT buffer/client/device"));
+    }
+
+    const size_t physical_size = unpacked.buffer.GetOnDeviceSizeInBytes();
+    if (physical_size == 0) {
+      throw std::invalid_argument(absl::StrCat(
+          "kv_cache_tensors[", layer_id, "] has an empty physical buffer"));
+    }
+    if (physical_size % page_nbytes != 0) {
+      throw std::invalid_argument(absl::StrCat(
+          "kv_cache_tensors[", layer_id, "] has ", physical_size,
+          " physical bytes, which is not divisible by page_nbytes=",
+          page_nbytes));
+    }
+
+    xla::PjRtClient* client = unpacked.buffer.buffer->client();
+    const int global_device_id =
+        unpacked.buffer.device->global_device_id().value();
+    if (layer_id == 0) {
+      expected_physical_size = physical_size;
+      expected_client = client;
+      expected_global_device_id = global_device_id;
+      state->num_blocks = physical_size / page_nbytes;
+      state->client = client;
+    } else {
+      if (physical_size != expected_physical_size) {
+        throw std::invalid_argument(absl::StrCat(
+            "all kv_cache_tensors must have the same physical size; layer 0 "
+            "has ",
+            expected_physical_size, " bytes, but layer ", layer_id, " has ",
+            physical_size, " bytes"));
+      }
+      if (client != expected_client ||
+          global_device_id != expected_global_device_id) {
+        throw std::invalid_argument(absl::StrCat(
+            "all kv_cache_tensors must belong to the same PJRT client and "
+            "device; layer 0 uses global device ",
+            expected_global_device_id, " but layer ", layer_id, " uses ",
+            global_device_id));
+      }
+    }
+
+    state->layers.push_back(DeviceState::Layer{
+        .tensor = tensor,
+        .ref = std::move(unpacked.ref),
+        .buffer = std::move(unpacked.buffer),
+    });
+  }
+  return state;
+}
+
+KVCacheOffloader::KVCacheOffloader(
+    const std::vector<at::Tensor>& kv_cache_tensors, size_t page_nbytes)
+    : KVCacheOffloader(kv_cache_tensors, page_nbytes, /*platform=*/nullptr) {}
+
+KVCacheOffloader::KVCacheOffloader(
+    const std::vector<at::Tensor>& kv_cache_tensors, size_t page_nbytes,
+    std::shared_ptr<offloader_internal::OffloaderPlatform> platform)
+    : device_state_(PrepareDeviceState(kv_cache_tensors, page_nbytes)),
+      platform_(platform == nullptr
+                    ? CreateDefaultOffloaderPlatform(device_state_->client)
+                    : std::move(platform)) {}
+
+KVCacheOffloader::KVCacheOffloader(
+    std::shared_ptr<offloader_internal::OffloaderPlatform> platform)
+    : platform_(std::move(platform)) {}
+
+KVCacheOffloader::~KVCacheOffloader() {
+  bool needs_cleanup = false;
+  {
+    std::lock_guard<std::mutex> lock(mapping_mutex_);
+    needs_cleanup = mapping_phase_ != MappingPhase::kUnmapped;
+  }
+  if (!needs_cleanup) return;
+  const absl::Status status = UnmapSharedMemory();
+  if (!status.ok()) {
+    LOG(ERROR) << "KVCacheOffloader cleanup failed: " << status;
+  }
+}
+
+absl::Status KVCacheOffloader::MapSharedMemory(void* mapped_address,
+                                               size_t pool_size_bytes) {
+  if (mapped_address == nullptr) {
+    return absl::InvalidArgumentError("mapped_address must be non-null");
+  }
+  if (pool_size_bytes == 0) {
+    return absl::InvalidArgumentError(
+        "pool_size_bytes must be greater than zero");
+  }
+
+  absl::StatusOr<size_t> page_size = platform_->page_size();
+  if (!page_size.ok()) return page_size.status();
+  if (*page_size == 0) {
+    return absl::InternalError("system page size must be greater than zero");
+  }
+  const uintptr_t address_value = reinterpret_cast<uintptr_t>(mapped_address);
+  if (address_value % *page_size != 0) {
+    return absl::InvalidArgumentError(
+        absl::StrCat("mapped_address=", address_value,
+                     " must be aligned to system page size ", *page_size));
+  }
+  if (pool_size_bytes % *page_size != 0) {
+    return absl::InvalidArgumentError(
+        absl::StrCat("pool_size_bytes=", pool_size_bytes,
+                     " must be aligned to system page size ", *page_size));
+  }
+  if (pool_size_bytes > std::numeric_limits<uintptr_t>::max() - address_value) {
+    return absl::InvalidArgumentError(
+        "mapped_address + pool_size_bytes overflows the process address "
+        "space");
+  }
+
+  {
+    std::lock_guard<std::mutex> lock(mapping_mutex_);
+    if (mapping_phase_ != MappingPhase::kUnmapped) {
+      return absl::FailedPreconditionError(
+          "shared memory is already mapped or registration is in progress");
+    }
+    mapping_phase_ = MappingPhase::kMapping;
+  }
+
+  const auto reset_mapping_reservation = [this]() {
+    std::lock_guard<std::mutex> lock(mapping_mutex_);
+    assert(mapping_phase_ == MappingPhase::kMapping &&
+           "map failure must still own the mapping reservation");
+    mapping_phase_ = MappingPhase::kUnmapped;
+  };
+
+  const absl::Status status =
+      platform_->dma_map(mapped_address, pool_size_bytes);
+  if (!status.ok()) {
+    reset_mapping_reservation();
+    return status;
+  }
+
+  {
+    std::lock_guard<std::mutex> lock(mapping_mutex_);
+    assert(mapping_phase_ == MappingPhase::kMapping &&
+           "successful map must still own the mapping reservation");
+    mapped_address_ = mapped_address;
+    mapping_phase_ = MappingPhase::kMapped;
+  }
+  return absl::OkStatus();
+}
+
+absl::Status KVCacheOffloader::UnmapSharedMemory() {
+  void* mapped_address = nullptr;
+  std::vector<raiden::PjRtCopyFuture> copies_to_await;
+  absl::Status copy_status = absl::OkStatus();
+  {
+    std::lock_guard<std::mutex> lock(mapping_mutex_);
+    if (mapping_phase_ == MappingPhase::kUnmapped) {
+      return absl::FailedPreconditionError("shared memory is not mapped");
+    }
+    if (mapping_phase_ == MappingPhase::kMapping) {
+      return absl::FailedPreconditionError(
+          "shared memory mapping is still in progress");
+    }
+    if (mapping_phase_ == MappingPhase::kUnmapping) {
+      return absl::FailedPreconditionError(
+          "shared memory is already being unmapped");
+    }
+    assert(mapped_address_ != nullptr &&
+           "mapped phase must retain the registered address");
+    mapped_address = mapped_address_;
+    copies_to_await = std::move(in_flight_copies_);
+    copy_status = std::move(deferred_copy_error_);
+    deferred_copy_error_ = absl::OkStatus();
+    mapping_phase_ = MappingPhase::kUnmapping;
+  }
+
+  for (raiden::PjRtCopyFuture& future : copies_to_await) {
+    copy_status = FirstError(std::move(copy_status), future.Await());
+  }
+
+  const absl::Status status = platform_->dma_unmap(mapped_address);
+  if (!status.ok()) {
+    std::lock_guard<std::mutex> lock(mapping_mutex_);
+    deferred_copy_error_ =
+        FirstError(std::move(deferred_copy_error_), copy_status);
+    mapping_phase_ = MappingPhase::kMapped;
+    return status;
+  }
+
+  {
+    std::lock_guard<std::mutex> lock(mapping_mutex_);
+    mapped_address_ = nullptr;
+    deferred_copy_error_ = absl::OkStatus();
+    mapping_phase_ = MappingPhase::kUnmapped;
+  }
+  return copy_status;
+}
+
+bool KVCacheOffloader::is_shared_memory_mapped() const {
+  std::lock_guard<std::mutex> lock(mapping_mutex_);
+  return mapping_phase_ == MappingPhase::kMapped;
+}
+
+absl::StatusOr<raiden::PjRtCopyFuture> KVCacheOffloader::H2d(
+    const std::vector<int64_t>& block_ids,
+    const std::vector<at::Tensor>& object_tensors, int64_t rank_id) {
+  return CopyBlocks(block_ids, object_tensors, rank_id,
+                    CopyDirection::kHostToDevice);
+}
+
+absl::StatusOr<raiden::PjRtCopyFuture> KVCacheOffloader::D2h(
+    const std::vector<int64_t>& block_ids,
+    const std::vector<at::Tensor>& object_tensors, int64_t rank_id) {
+  return CopyBlocks(block_ids, object_tensors, rank_id,
+                    CopyDirection::kDeviceToHost);
+}
+
+absl::StatusOr<raiden::PjRtCopyFuture> KVCacheOffloader::CopyBlocks(
+    const std::vector<int64_t>& block_ids,
+    const std::vector<at::Tensor>& object_tensors, int64_t rank_id,
+    CopyDirection direction) {
+  if (device_state_ == nullptr) {
+    return absl::FailedPreconditionError(
+        "KVCacheOffloader has no registered device KV cache");
+  }
+  if (block_ids.empty()) {
+    return absl::InvalidArgumentError("block_ids must not be empty");
+  }
+  if (block_ids.size() != object_tensors.size()) {
+    return absl::InvalidArgumentError(absl::StrCat(
+        "block_ids and object_tensors must have the same length; got ",
+        block_ids.size(), " and ", object_tensors.size()));
+  }
+  if (rank_id < 0) {
+    return absl::InvalidArgumentError("rank_id must be non-negative");
+  }
+
+  std::unordered_set<int64_t> unique_blocks;
+  unique_blocks.reserve(block_ids.size());
+  std::vector<int64_t> device_offsets;
+  device_offsets.reserve(block_ids.size());
+  for (size_t object_id = 0; object_id < block_ids.size(); ++object_id) {
+    const int64_t block_id = block_ids[object_id];
+    if (block_id < 0 ||
+        static_cast<size_t>(block_id) >= device_state_->num_blocks) {
+      return absl::OutOfRangeError(absl::StrCat(
+          "block_ids[", object_id, "]=", block_id,
+          " is outside block range [0, ", device_state_->num_blocks, ")"));
+    }
+    if (!unique_blocks.insert(block_id).second) {
+      return absl::InvalidArgumentError(absl::StrCat(
+          "block_ids contains duplicate block ", block_id,
+          "; concurrent writes to one block have undefined ordering"));
+    }
+    absl::StatusOr<size_t> offset =
+        CheckedMultiply(static_cast<size_t>(block_id),
+                        device_state_->page_nbytes, "device page offset");
+    if (!offset.ok()) return offset.status();
+    if (*offset > static_cast<size_t>(std::numeric_limits<int64_t>::max())) {
+      return absl::OutOfRangeError(
+          "device page offset does not fit in int64_t");
+    }
+    device_offsets.push_back(static_cast<int64_t>(*offset));
+  }
+
+  absl::StatusOr<size_t> rank_bytes =
+      CheckedMultiply(device_state_->num_layers, device_state_->page_nbytes,
+                      "object tensor bytes per rank");
+  if (!rank_bytes.ok()) return rank_bytes.status();
+
+  size_t expected_num_ranks = 0;
+  size_t expected_object_bytes = 0;
+  std::vector<uint8_t*> host_bases;
+  host_bases.reserve(object_tensors.size());
+  for (size_t object_id = 0; object_id < object_tensors.size(); ++object_id) {
+    const at::Tensor& tensor = object_tensors[object_id];
+    if (!tensor.device().is_cpu()) {
+      return absl::InvalidArgumentError(
+          absl::StrCat("object_tensors[", object_id, "] must be a CPU tensor"));
+    }
+    if (!tensor.is_contiguous()) {
+      return absl::InvalidArgumentError(absl::StrCat(
+          "object_tensors[", object_id,
+          "] must be contiguous; a nonzero storage offset is allowed"));
+    }
+    if (tensor.dim() != 3 || tensor.scalar_type() != at::ScalarType::Char) {
+      return absl::InvalidArgumentError(absl::StrCat(
+          "object_tensors[", object_id,
+          "] must be a rank-3 CPU int8 tensor with shape [num_ranks, ",
+          device_state_->num_layers, ", ", device_state_->page_nbytes, "]"));
+    }
+    if (tensor.size(0) <= 0 ||
+        tensor.size(1) != static_cast<int64_t>(device_state_->num_layers) ||
+        tensor.size(2) != static_cast<int64_t>(device_state_->page_nbytes)) {
+      return absl::InvalidArgumentError(absl::StrCat(
+          "object_tensors[", object_id, "] must have shape [num_ranks, ",
+          device_state_->num_layers, ", ", device_state_->page_nbytes,
+          "] with num_ranks > 0"));
+    }
+
+    const size_t num_ranks = static_cast<size_t>(tensor.size(0));
+    if (object_id == 0) {
+      expected_num_ranks = num_ranks;
+      absl::StatusOr<size_t> object_bytes =
+          CheckedMultiply(num_ranks, *rank_bytes, "object tensor byte size");
+      if (!object_bytes.ok()) return object_bytes.status();
+      expected_object_bytes = *object_bytes;
+    } else if (num_ranks != expected_num_ranks) {
+      return absl::InvalidArgumentError(
+          "all object_tensors must have the same num_ranks dimension");
+    }
+    if (static_cast<size_t>(rank_id) >= num_ranks) {
+      return absl::OutOfRangeError(
+          absl::StrCat("rank_id=", rank_id, " is outside object_tensors[",
+                       object_id, "] first dimension [0, ", num_ranks, ")"));
+    }
+    if (static_cast<size_t>(tensor.nbytes()) != expected_object_bytes) {
+      return absl::InvalidArgumentError(
+          absl::StrCat("object_tensors[", object_id, "] has ", tensor.nbytes(),
+                       " bytes, expected ", expected_object_bytes));
+    }
+
+    auto* host_base = static_cast<uint8_t*>(tensor.data_ptr());
+    host_bases.push_back(host_base);
+  }
+
+  absl::StatusOr<size_t> host_rank_offset = CheckedMultiply(
+      static_cast<size_t>(rank_id), *rank_bytes, "object tensor rank offset");
+  if (!host_rank_offset.ok()) return host_rank_offset.status();
+  std::vector<size_t> host_layer_offsets;
+  host_layer_offsets.reserve(device_state_->num_layers);
+  for (size_t layer_id = 0; layer_id < device_state_->num_layers; ++layer_id) {
+    absl::StatusOr<size_t> layer_offset = CheckedMultiply(
+        layer_id, device_state_->page_nbytes, "object tensor layer offset");
+    if (!layer_offset.ok()) return layer_offset.status();
+    absl::StatusOr<size_t> host_offset = CheckedAdd(
+        *host_rank_offset, *layer_offset, "object tensor host offset");
+    if (!host_offset.ok()) return host_offset.status();
+    assert(*host_offset <= expected_object_bytes - device_state_->page_nbytes &&
+           "validated rank/layer geometry must stay inside the object view");
+    host_layer_offsets.push_back(*host_offset);
+  }
+
+  auto tensor_holds = std::make_shared<std::vector<at::Tensor>>(object_tensors);
+  std::vector<raiden::PjRtCopyFuture> layer_futures;
+  layer_futures.reserve(device_state_->num_layers);
+
+  std::lock_guard<std::mutex> lock(mapping_mutex_);
+  if (mapping_phase_ != MappingPhase::kMapped) {
+    return absl::FailedPreconditionError(
+        "shared memory must be mapped before submitting a copy");
+  }
+  auto first_pending =
+      std::remove_if(in_flight_copies_.begin(), in_flight_copies_.end(),
+                     [this](raiden::PjRtCopyFuture& future) {
+                       if (!future.IsReady()) return false;
+                       deferred_copy_error_ = FirstError(
+                           std::move(deferred_copy_error_), future.PollError());
+                       return true;
+                     });
+  in_flight_copies_.erase(first_pending, in_flight_copies_.end());
+
+  const int64_t transfer_size =
+      static_cast<int64_t>(device_state_->page_nbytes);
+  for (size_t layer_id = 0; layer_id < device_state_->num_layers; ++layer_id) {
+    const size_t host_offset = host_layer_offsets[layer_id];
+
+    absl::StatusOr<raiden::PjRtCopyFuture> future;
+    if (direction == CopyDirection::kHostToDevice) {
+      std::vector<raiden::H2dCopy> copies;
+      copies.reserve(object_tensors.size());
+      for (size_t object_id = 0; object_id < object_tensors.size();
+           ++object_id) {
+        copies.push_back(raiden::H2dCopy{
+            .src = host_bases[object_id] + host_offset,
+            .dst_off = device_offsets[object_id],
+            .size = transfer_size,
+        });
+      }
+      future =
+          raiden::IssueH2dShard(device_state_->layers[layer_id].buffer, copies);
+    } else {
+      std::vector<raiden::D2hCopy> copies;
+      copies.reserve(object_tensors.size());
+      for (size_t object_id = 0; object_id < object_tensors.size();
+           ++object_id) {
+        copies.push_back(raiden::D2hCopy{
+            .dst = host_bases[object_id] + host_offset,
+            .src_off = device_offsets[object_id],
+            .size = transfer_size,
+        });
+      }
+      future =
+          raiden::IssueD2hShard(device_state_->layers[layer_id].buffer, copies);
+    }
+    if (!future.ok()) {
+      if (!layer_futures.empty()) {
+        raiden::PjRtCopyFuture submitted =
+            raiden::JoinPjRtCopyFutures(layer_futures);
+        submitted.AddKeepAlive(tensor_holds);
+        submitted.AddKeepAlive(device_state_);
+        in_flight_copies_.push_back(std::move(submitted));
+      }
+      return future.status();
+    }
+    layer_futures.push_back(std::move(future.value()));
+  }
+
+  raiden::PjRtCopyFuture joined = raiden::JoinPjRtCopyFutures(layer_futures);
+  joined.AddKeepAlive(std::move(tensor_holds));
+  joined.AddKeepAlive(device_state_);
+  in_flight_copies_.push_back(joined);
+  return joined;
+}
+
+size_t KVCacheOffloader::num_layers() const {
+  return device_state_ == nullptr ? 0 : device_state_->num_layers;
+}
+
+size_t KVCacheOffloader::num_blocks() const {
+  return device_state_ == nullptr ? 0 : device_state_->num_blocks;
+}
+
+size_t KVCacheOffloader::page_nbytes() const {
+  return device_state_ == nullptr ? 0 : device_state_->page_nbytes;
+}
+
+}  // namespace tpu_raiden::torch

--- a/tpu_sync/frameworks/torch/kv_cache_offloader.h
+++ b/tpu_sync/frameworks/torch/kv_cache_offloader.h
@@ -1,0 +1,115 @@
+// Copyright 2026 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TPU_SYNC_FRAMEWORKS_TORCH_KV_CACHE_OFFLOADER_H_
+#define TPU_SYNC_FRAMEWORKS_TORCH_KV_CACHE_OFFLOADER_H_
+
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <vector>
+
+#include "ATen/core/TensorBody.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "tpu_sync/core/raw_transfer_core.h"
+
+namespace tpu_raiden::torch {
+
+namespace offloader_internal {
+
+inline constexpr char kPosixErrorPayloadUrl[] =
+    "type.googleapis.com/tpu_raiden.kv_cache_offloader.PosixError";
+
+// The operating-system and PJRT boundary used by KVCacheOffloader. Production
+// installs direct POSIX/PJRT functions; tests replace them to verify ordering
+// and registration lifetime without exposing these seams in the Python API.
+struct OffloaderPlatform {
+  std::function<absl::StatusOr<size_t>()> page_size;
+  std::function<absl::Status(void*, size_t)> dma_map;
+  std::function<absl::Status(void*)> dma_unmap;
+};
+
+class KVCacheOffloaderTestPeer;
+
+}  // namespace offloader_internal
+
+class KVCacheOffloader final {
+ public:
+  // Splits each same-sized device buffer into fixed-size raw byte pages.
+  KVCacheOffloader(const std::vector<at::Tensor>& kv_cache_tensors,
+                   size_t page_nbytes);
+  KVCacheOffloader(const KVCacheOffloader&) = delete;
+  KVCacheOffloader& operator=(const KVCacheOffloader&) = delete;
+  ~KVCacheOffloader();
+
+  absl::Status MapSharedMemory(void* mapped_address, size_t pool_size_bytes);
+  absl::Status UnmapSharedMemory();
+  bool is_shared_memory_mapped() const;
+
+  absl::StatusOr<raiden::PjRtCopyFuture> H2d(
+      const std::vector<int64_t>& block_ids,
+      const std::vector<at::Tensor>& object_tensors, int64_t rank_id);
+  absl::StatusOr<raiden::PjRtCopyFuture> D2h(
+      const std::vector<int64_t>& block_ids,
+      const std::vector<at::Tensor>& object_tensors, int64_t rank_id);
+
+  size_t num_layers() const;
+  size_t num_blocks() const;
+  size_t page_nbytes() const;
+
+ private:
+  friend class offloader_internal::KVCacheOffloaderTestPeer;
+
+  struct DeviceState;
+
+  enum class CopyDirection {
+    kHostToDevice,
+    kDeviceToHost,
+  };
+
+  explicit KVCacheOffloader(
+      std::shared_ptr<offloader_internal::OffloaderPlatform> platform);
+  KVCacheOffloader(
+      const std::vector<at::Tensor>& kv_cache_tensors, size_t page_nbytes,
+      std::shared_ptr<offloader_internal::OffloaderPlatform> platform);
+
+  static std::shared_ptr<DeviceState> PrepareDeviceState(
+      const std::vector<at::Tensor>& kv_cache_tensors, size_t page_nbytes);
+  absl::StatusOr<raiden::PjRtCopyFuture> CopyBlocks(
+      const std::vector<int64_t>& block_ids,
+      const std::vector<at::Tensor>& object_tensors, int64_t rank_id,
+      CopyDirection direction);
+
+  enum class MappingPhase {
+    kUnmapped,
+    kMapping,
+    kMapped,
+    kUnmapping,
+  };
+
+  std::shared_ptr<DeviceState> device_state_;
+  std::shared_ptr<offloader_internal::OffloaderPlatform> platform_;
+  mutable std::mutex mapping_mutex_;
+  MappingPhase mapping_phase_ = MappingPhase::kUnmapped;
+  void* mapped_address_ = nullptr;
+  std::vector<raiden::PjRtCopyFuture> in_flight_copies_;
+  absl::Status deferred_copy_error_ = absl::OkStatus();
+};
+
+}  // namespace tpu_raiden::torch
+
+#endif  // TPU_SYNC_FRAMEWORKS_TORCH_KV_CACHE_OFFLOADER_H_

--- a/tpu_sync/frameworks/torch/kv_cache_offloader_test.cc
+++ b/tpu_sync/frameworks/torch/kv_cache_offloader_test.cc
@@ -1,0 +1,564 @@
+// Copyright 2026 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "tpu_sync/frameworks/torch/kv_cache_offloader.h"
+
+#include <algorithm>
+#include <condition_variable>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+#include "ATen/core/TensorBody.h"
+#include "ATen/ops/zeros.h"
+#include "absl/status/status.h"
+#include "c10/util/intrusive_ptr.h"
+#include "tpu_sync/frameworks/torch/torch_tpu_utils_mock.h"
+#include "xla/pjrt/pjrt_client.h"
+#include "xla/pjrt/plugin/xla_cpu/xla_cpu_pjrt_client.h"
+#include "xla/tsl/platform/statusor.h"
+#include "xla/tsl/platform/test.h"
+
+namespace tpu_raiden::torch {
+namespace offloader_internal {
+
+class KVCacheOffloaderTestPeer {
+ public:
+  static std::unique_ptr<KVCacheOffloader> Create(
+      std::shared_ptr<OffloaderPlatform> platform) {
+    return std::unique_ptr<KVCacheOffloader>(
+        new KVCacheOffloader(std::move(platform)));
+  }
+
+  static std::unique_ptr<KVCacheOffloader> CreateWithTensors(
+      const std::vector<at::Tensor>& kv_cache_tensors, size_t page_nbytes,
+      std::shared_ptr<OffloaderPlatform> platform) {
+    return std::unique_ptr<KVCacheOffloader>(new KVCacheOffloader(
+        kv_cache_tensors, page_nbytes, std::move(platform)));
+  }
+};
+
+}  // namespace offloader_internal
+namespace {
+
+using ::tpu_raiden::torch::RegisterMockTensor;
+using ::tpu_raiden::torch::offloader_internal::KVCacheOffloaderTestPeer;
+using ::tpu_raiden::torch::offloader_internal::OffloaderPlatform;
+
+constexpr size_t kPageSize = 4096;
+constexpr size_t kPoolSize = 2 * kPageSize;
+void* const kMappedAddress = reinterpret_cast<void*>(0x40000000);
+
+struct MappingRecorder {
+  std::vector<std::string> calls;
+  absl::Status dma_map_status = absl::OkStatus();
+  absl::Status dma_unmap_status = absl::OkStatus();
+  void* observed_dma_map_address = nullptr;
+  void* observed_dma_unmap_address = nullptr;
+};
+
+std::shared_ptr<OffloaderPlatform> RecordingPlatform(
+    std::shared_ptr<MappingRecorder> recorder) {
+  auto platform = std::make_shared<OffloaderPlatform>();
+  platform->page_size = [recorder]() {
+    recorder->calls.push_back("page_size");
+    return absl::StatusOr<size_t>(kPageSize);
+  };
+  platform->dma_map = [recorder](void* address, size_t size_bytes) {
+    recorder->calls.push_back("DmaMap");
+    recorder->observed_dma_map_address = address;
+    EXPECT_EQ(size_bytes, kPoolSize);
+    return recorder->dma_map_status;
+  };
+  platform->dma_unmap = [recorder](void* address) {
+    recorder->calls.push_back("DmaUnmap");
+    recorder->observed_dma_unmap_address = address;
+    return recorder->dma_unmap_status;
+  };
+  return platform;
+}
+
+TEST(KVCacheOffloaderMappingTest, RegistersAndUnregistersCallerMappingInOrder) {
+  auto recorder = std::make_shared<MappingRecorder>();
+  auto offloader =
+      KVCacheOffloaderTestPeer::Create(RecordingPlatform(recorder));
+
+  EXPECT_TRUE(offloader->MapSharedMemory(kMappedAddress, kPoolSize).ok());
+  EXPECT_TRUE(offloader->is_shared_memory_mapped());
+
+  EXPECT_TRUE(offloader->UnmapSharedMemory().ok());
+  EXPECT_FALSE(offloader->is_shared_memory_mapped());
+  EXPECT_EQ(recorder->observed_dma_unmap_address,
+            recorder->observed_dma_map_address);
+  EXPECT_EQ(recorder->calls,
+            (std::vector<std::string>{"page_size", "DmaMap", "DmaUnmap"}));
+}
+
+TEST(KVCacheOffloaderMappingTest,
+     RejectsInvalidAddressAndSizeBeforeDmaMap) {
+  auto recorder = std::make_shared<MappingRecorder>();
+  auto offloader =
+      KVCacheOffloaderTestPeer::Create(RecordingPlatform(recorder));
+
+  EXPECT_EQ(offloader->MapSharedMemory(nullptr, kPageSize).code(),
+            absl::StatusCode::kInvalidArgument);
+  EXPECT_EQ(offloader->MapSharedMemory(kMappedAddress, 0).code(),
+            absl::StatusCode::kInvalidArgument);
+  EXPECT_EQ(offloader->MapSharedMemory(kMappedAddress, kPageSize + 1).code(),
+            absl::StatusCode::kInvalidArgument);
+  EXPECT_EQ(offloader
+                ->MapSharedMemory(
+                    reinterpret_cast<void*>(
+                        reinterpret_cast<uintptr_t>(kMappedAddress) + 1),
+                    kPageSize)
+                .code(),
+            absl::StatusCode::kInvalidArgument);
+  const uintptr_t last_page = std::numeric_limits<uintptr_t>::max() -
+                              std::numeric_limits<uintptr_t>::max() % kPageSize;
+  EXPECT_EQ(
+      offloader->MapSharedMemory(reinterpret_cast<void*>(last_page), kPageSize)
+          .code(),
+      absl::StatusCode::kInvalidArgument);
+  EXPECT_EQ(recorder->calls,
+            (std::vector<std::string>{"page_size", "page_size", "page_size"}));
+}
+
+TEST(KVCacheOffloaderMappingTest, RejectsSecondActiveMapping) {
+  auto recorder = std::make_shared<MappingRecorder>();
+  auto offloader =
+      KVCacheOffloaderTestPeer::Create(RecordingPlatform(recorder));
+  ASSERT_TRUE(offloader->MapSharedMemory(kMappedAddress, kPoolSize).ok());
+
+  EXPECT_EQ(offloader->MapSharedMemory(kMappedAddress, kPoolSize).code(),
+            absl::StatusCode::kFailedPrecondition);
+  EXPECT_TRUE(offloader->UnmapSharedMemory().ok());
+}
+
+TEST(KVCacheOffloaderMappingTest,
+     DmaMapFailureReleasesRegistrationReservation) {
+  auto recorder = std::make_shared<MappingRecorder>();
+  recorder->dma_map_status = absl::InternalError("injected DmaMap failure");
+  auto offloader =
+      KVCacheOffloaderTestPeer::Create(RecordingPlatform(recorder));
+
+  EXPECT_EQ(offloader->MapSharedMemory(kMappedAddress, kPoolSize).code(),
+            absl::StatusCode::kInternal);
+  EXPECT_FALSE(offloader->is_shared_memory_mapped());
+  EXPECT_EQ(recorder->calls,
+            (std::vector<std::string>{"page_size", "DmaMap"}));
+
+  recorder->dma_map_status = absl::OkStatus();
+  EXPECT_TRUE(offloader->MapSharedMemory(kMappedAddress, kPoolSize).ok());
+  EXPECT_TRUE(offloader->UnmapSharedMemory().ok());
+}
+
+TEST(KVCacheOffloaderMappingTest, DmaUnmapFailureKeepsRegistrationForRetry) {
+  auto recorder = std::make_shared<MappingRecorder>();
+  auto offloader =
+      KVCacheOffloaderTestPeer::Create(RecordingPlatform(recorder));
+  ASSERT_TRUE(offloader->MapSharedMemory(kMappedAddress, kPoolSize).ok());
+  recorder->dma_unmap_status = absl::InternalError("injected DmaUnmap failure");
+
+  EXPECT_EQ(offloader->UnmapSharedMemory().code(), absl::StatusCode::kInternal);
+  EXPECT_TRUE(offloader->is_shared_memory_mapped());
+  EXPECT_EQ(recorder->calls.back(), "DmaUnmap");
+
+  recorder->dma_unmap_status = absl::OkStatus();
+  EXPECT_TRUE(offloader->UnmapSharedMemory().ok());
+  EXPECT_FALSE(offloader->is_shared_memory_mapped());
+}
+
+TEST(KVCacheOffloaderMappingTest, DestructorCleansUpActiveMapping) {
+  auto recorder = std::make_shared<MappingRecorder>();
+  {
+    auto offloader =
+        KVCacheOffloaderTestPeer::Create(RecordingPlatform(recorder));
+    ASSERT_TRUE(offloader->MapSharedMemory(kMappedAddress, kPoolSize).ok());
+  }
+
+  EXPECT_EQ(recorder->calls.back(), "DmaUnmap");
+  EXPECT_EQ(recorder->observed_dma_unmap_address,
+            recorder->observed_dma_map_address);
+}
+
+TEST(KVCacheOffloaderMappingTest, ConcurrentMapReservesStateBeforeDmaMap) {
+  auto platform = std::make_shared<OffloaderPlatform>();
+  std::mutex gate_mutex;
+  std::condition_variable gate_cv;
+  bool first_in_dma_map = false;
+  bool release_first = false;
+  int dma_map_calls = 0;
+
+  platform->page_size = [] { return absl::StatusOr<size_t>(kPageSize); };
+  platform->dma_map = [&](void*, size_t) {
+    std::unique_lock<std::mutex> lock(gate_mutex);
+    ++dma_map_calls;
+    first_in_dma_map = true;
+    gate_cv.notify_all();
+    gate_cv.wait(lock, [&] { return release_first; });
+    return absl::OkStatus();
+  };
+  platform->dma_unmap = [](void*) { return absl::OkStatus(); };
+
+  auto offloader = KVCacheOffloaderTestPeer::Create(platform);
+  absl::Status first_status;
+  std::thread first([&] {
+    first_status = offloader->MapSharedMemory(kMappedAddress, kPoolSize);
+  });
+  {
+    std::unique_lock<std::mutex> lock(gate_mutex);
+    gate_cv.wait(lock, [&] { return first_in_dma_map; });
+  }
+
+  const absl::Status second_status =
+      offloader->MapSharedMemory(kMappedAddress, kPoolSize);
+  EXPECT_EQ(second_status.code(), absl::StatusCode::kFailedPrecondition);
+  {
+    std::lock_guard<std::mutex> lock(gate_mutex);
+    release_first = true;
+  }
+  gate_cv.notify_all();
+  first.join();
+
+  EXPECT_TRUE(first_status.ok()) << first_status;
+  EXPECT_EQ(dma_map_calls, 1);
+  EXPECT_TRUE(offloader->UnmapSharedMemory().ok());
+}
+
+TEST(KVCacheOffloaderMappingTest, UnmapRejectsMappingInProgress) {
+  auto platform = std::make_shared<OffloaderPlatform>();
+  std::mutex gate_mutex;
+  std::condition_variable gate_cv;
+  bool map_in_dma_map = false;
+  bool release_map = false;
+
+  platform->page_size = [] { return absl::StatusOr<size_t>(kPageSize); };
+  platform->dma_map = [&](void*, size_t) {
+    std::unique_lock<std::mutex> lock(gate_mutex);
+    map_in_dma_map = true;
+    gate_cv.notify_all();
+    gate_cv.wait(lock, [&] { return release_map; });
+    return absl::OkStatus();
+  };
+  platform->dma_unmap = [](void*) { return absl::OkStatus(); };
+
+  auto offloader = KVCacheOffloaderTestPeer::Create(platform);
+  absl::Status map_status;
+  std::thread map_thread([&] {
+    map_status = offloader->MapSharedMemory(kMappedAddress, kPoolSize);
+  });
+  {
+    std::unique_lock<std::mutex> lock(gate_mutex);
+    gate_cv.wait(lock, [&] { return map_in_dma_map; });
+  }
+
+  EXPECT_EQ(offloader->UnmapSharedMemory().code(),
+            absl::StatusCode::kFailedPrecondition);
+  {
+    std::lock_guard<std::mutex> lock(gate_mutex);
+    release_map = true;
+  }
+  gate_cv.notify_all();
+  map_thread.join();
+
+  EXPECT_TRUE(map_status.ok()) << map_status;
+  EXPECT_TRUE(offloader->UnmapSharedMemory().ok());
+}
+
+class KVCacheOffloaderCopyTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    TF_ASSERT_OK_AND_ASSIGN(client_,
+                            xla::GetXlaPjrtCpuClient(xla::CpuClientOptions()));
+    TF_ASSERT_OK_AND_ASSIGN(
+        memory_space_,
+        client_->addressable_devices()[0]->default_memory_space());
+  }
+
+  at::Tensor AddLayer(int64_t kernel_blocks, int64_t elements_per_block,
+                      float initial_value = 0.0f) {
+    std::vector<float> initial(
+        static_cast<size_t>(kernel_blocks * elements_per_block), initial_value);
+    auto buffer_or = client_->BufferFromHostBuffer(
+        initial.data(), xla::F32, {kernel_blocks, elements_per_block},
+        /*byte_strides=*/std::nullopt,
+        xla::PjRtClient::HostBufferSemantics::kImmutableUntilTransferCompletes,
+        /*on_done_with_host_buffer=*/nullptr, memory_space_,
+        /*device_layout=*/nullptr);
+    EXPECT_TRUE(buffer_or.ok()) << buffer_or.status();
+    if (!buffer_or.ok()) return at::Tensor();
+    EXPECT_TRUE(buffer_or.value()->GetReadyFuture().Await().ok());
+
+    at::Tensor tensor = at::zeros({kernel_blocks, elements_per_block});
+    RegisterMockTensor(tensor, buffer_or.value().get());
+    buffers_.push_back(std::move(buffer_or.value()));
+    return tensor;
+  }
+
+  at::Tensor ObjectView(size_t prefix_bytes, int64_t num_ranks,
+                        int64_t num_layers, int64_t page_nbytes) {
+    const int64_t object_bytes = num_ranks * num_layers * page_nbytes;
+    at::Tensor backing = at::zeros(
+        {static_cast<int64_t>(prefix_bytes) + object_bytes + 7}, at::kChar);
+    backings_.push_back(backing);
+    return backing.narrow(0, static_cast<int64_t>(prefix_bytes), object_bytes)
+        .view({num_ranks, num_layers, page_nbytes});
+  }
+
+  std::unique_ptr<KVCacheOffloader> CreateMappedOffloader(
+      const std::vector<at::Tensor>& layers, size_t page_nbytes,
+      std::shared_ptr<MappingRecorder> recorder =
+          std::make_shared<MappingRecorder>()) {
+    auto offloader = KVCacheOffloaderTestPeer::CreateWithTensors(
+        layers, page_nbytes, RecordingPlatform(std::move(recorder)));
+    EXPECT_TRUE(offloader->MapSharedMemory(kMappedAddress, kPoolSize).ok());
+    return offloader;
+  }
+
+  void ExpectLayerBytes(xla::PjRtBuffer* buffer, size_t offset,
+                        const int8_t* expected, size_t size) {
+    std::vector<int8_t> actual(size);
+    EXPECT_TRUE(
+        buffer->CopyRawToHost(actual.data(), offset, size).Await().ok());
+    EXPECT_EQ(actual, std::vector<int8_t>(expected, expected + size));
+  }
+
+  std::unique_ptr<xla::PjRtClient> client_;
+  xla::PjRtMemorySpace* memory_space_ = nullptr;
+  std::vector<std::unique_ptr<xla::PjRtBuffer>> buffers_;
+  std::vector<at::Tensor> backings_;
+};
+
+TEST_F(KVCacheOffloaderCopyTest,
+       CopiesFullNonZeroOffsetObjectViewsInBothDirections) {
+  constexpr size_t kPageBytes = 2 * 4 * sizeof(float);
+  std::vector<at::Tensor> layers = {AddLayer(4, 4), AddLayer(4, 4)};
+  auto offloader = CreateMappedOffloader(layers, kPageBytes);
+
+  at::Tensor source0 = ObjectView(/*prefix_bytes=*/11, /*num_ranks=*/2,
+                                  /*num_layers=*/2, kPageBytes);
+  at::Tensor source1 = ObjectView(/*prefix_bytes=*/19, /*num_ranks=*/2,
+                                  /*num_layers=*/2, kPageBytes);
+  ASSERT_GT(source0.storage_offset(), 0);
+  ASSERT_GT(source1.storage_offset(), 0);
+  auto fill_rank = [](at::Tensor tensor, int64_t rank, int8_t seed) {
+    auto* bytes = static_cast<int8_t*>(tensor.data_ptr());
+    const size_t rank_offset =
+        static_cast<size_t>(rank * tensor.size(1) * tensor.size(2));
+    for (size_t i = 0; i < static_cast<size_t>(tensor.size(1) * tensor.size(2));
+         ++i) {
+      bytes[rank_offset + i] = static_cast<int8_t>(seed + i);
+    }
+  };
+  fill_rank(source0, /*rank=*/1, /*seed=*/10);
+  fill_rank(source1, /*rank=*/1, /*seed=*/70);
+
+  auto h2d = offloader->H2d(/*block_ids=*/{1, 0}, {source0, source1},
+                            /*rank_id=*/1);
+  ASSERT_TRUE(h2d.ok()) << h2d.status();
+  ASSERT_TRUE(h2d->Await().ok());
+
+  at::Tensor destination0 = ObjectView(/*prefix_bytes=*/13, /*num_ranks=*/2,
+                                       /*num_layers=*/2, kPageBytes);
+  at::Tensor destination1 = ObjectView(/*prefix_bytes=*/23, /*num_ranks=*/2,
+                                       /*num_layers=*/2, kPageBytes);
+  auto d2h = offloader->D2h(/*block_ids=*/{1, 0}, {destination0, destination1},
+                            /*rank_id=*/0);
+  ASSERT_TRUE(d2h.ok()) << d2h.status();
+  ASSERT_TRUE(d2h->Await().ok());
+
+  const size_t rank_bytes = 2 * kPageBytes;
+  EXPECT_EQ(std::memcmp(destination0.data_ptr(),
+                        static_cast<int8_t*>(source0.data_ptr()) + rank_bytes,
+                        rank_bytes),
+            0);
+  EXPECT_EQ(std::memcmp(destination1.data_ptr(),
+                        static_cast<int8_t*>(source1.data_ptr()) + rank_bytes,
+                        rank_bytes),
+            0);
+  const auto* untouched =
+      static_cast<const int8_t*>(destination0.data_ptr()) + rank_bytes;
+  EXPECT_TRUE(std::all_of(untouched, untouched + rank_bytes,
+                          [](int8_t value) { return value == 0; }));
+
+  EXPECT_EQ(offloader->num_layers(), 2);
+  EXPECT_EQ(offloader->num_blocks(), 2);
+  EXPECT_EQ(offloader->page_nbytes(), kPageBytes);
+  EXPECT_TRUE(offloader->UnmapSharedMemory().ok());
+}
+
+TEST_F(KVCacheOffloaderCopyTest,
+       TreatsSameSizedDifferentShapeLayersAsRawBytePages) {
+  constexpr size_t kPageBytes = 32;
+  std::vector<at::Tensor> layers = {AddLayer(4, 4), AddLayer(2, 8)};
+  auto offloader = CreateMappedOffloader(layers, kPageBytes);
+
+  at::Tensor source = ObjectView(/*prefix_bytes=*/5, /*num_ranks=*/1,
+                                 /*num_layers=*/2, kPageBytes);
+  auto* source_bytes = static_cast<int8_t*>(source.data_ptr());
+  for (size_t byte = 0; byte < source.nbytes(); ++byte) {
+    source_bytes[byte] = static_cast<int8_t>(byte + 1);
+  }
+  auto h2d = offloader->H2d(/*block_ids=*/{1}, {source}, /*rank_id=*/0);
+  ASSERT_TRUE(h2d.ok()) << h2d.status();
+  ASSERT_TRUE(h2d->Await().ok());
+
+  at::Tensor destination = ObjectView(/*prefix_bytes=*/7, /*num_ranks=*/1,
+                                      /*num_layers=*/2, kPageBytes);
+  auto d2h = offloader->D2h(/*block_ids=*/{1}, {destination}, /*rank_id=*/0);
+  ASSERT_TRUE(d2h.ok()) << d2h.status();
+  ASSERT_TRUE(d2h->Await().ok());
+
+  EXPECT_EQ(std::memcmp(destination.data_ptr(), source.data_ptr(),
+                        source.nbytes()),
+            0);
+  EXPECT_TRUE(offloader->UnmapSharedMemory().ok());
+}
+
+TEST_F(KVCacheOffloaderCopyTest,
+       ReleasesCompletedObjectViewsBeforeSubmittingTheNextCopy) {
+  constexpr size_t kPageBytes = 32;
+  std::vector<at::Tensor> layers = {AddLayer(4, 4)};
+  auto offloader = CreateMappedOffloader(layers, kPageBytes);
+
+  at::Tensor first = ObjectView(11, 1, 1, kPageBytes);
+  c10::weak_intrusive_ptr<c10::TensorImpl> first_view(first.getIntrusivePtr());
+  {
+    auto copy = offloader->H2d({0}, {first}, /*rank_id=*/0);
+    ASSERT_TRUE(copy.ok()) << copy.status();
+    ASSERT_TRUE(copy->Await().ok());
+  }
+  first = at::Tensor();
+  ASSERT_FALSE(first_view.expired());
+
+  at::Tensor second = ObjectView(13, 1, 1, kPageBytes);
+  auto copy = offloader->H2d({1}, {second}, /*rank_id=*/0);
+  ASSERT_TRUE(copy.ok()) << copy.status();
+  EXPECT_TRUE(first_view.expired());
+  EXPECT_TRUE(copy->Await().ok());
+  EXPECT_TRUE(offloader->UnmapSharedMemory().ok());
+}
+
+TEST_F(KVCacheOffloaderCopyTest, RejectsInvalidDeviceGeometry) {
+  at::Tensor four_blocks = AddLayer(4, 4);
+  EXPECT_THROW(KVCacheOffloaderTestPeer::CreateWithTensors(
+                   {four_blocks}, /*page_nbytes=*/24,
+                   RecordingPlatform(std::make_shared<MappingRecorder>())),
+               std::invalid_argument);
+
+  at::Tensor three_blocks = AddLayer(3, 4);
+  EXPECT_THROW(KVCacheOffloaderTestPeer::CreateWithTensors(
+                   {three_blocks}, /*page_nbytes=*/32,
+                   RecordingPlatform(std::make_shared<MappingRecorder>())),
+               std::invalid_argument);
+
+  at::Tensor different_slice = AddLayer(4, 8);
+  EXPECT_THROW(KVCacheOffloaderTestPeer::CreateWithTensors(
+                   {four_blocks, different_slice}, /*page_nbytes=*/32,
+                   RecordingPlatform(std::make_shared<MappingRecorder>())),
+               std::invalid_argument);
+
+  EXPECT_THROW(
+      KVCacheOffloaderTestPeer::CreateWithTensors(
+          {four_blocks},
+          static_cast<size_t>(std::numeric_limits<int64_t>::max()) + size_t{1},
+          RecordingPlatform(std::make_shared<MappingRecorder>())),
+      std::overflow_error);
+}
+
+TEST_F(KVCacheOffloaderCopyTest, ValidatesEveryArgumentBeforeIssuingCopies) {
+  constexpr size_t kPageBytes = 32;
+  std::vector<at::Tensor> layers = {AddLayer(4, 4), AddLayer(4, 4)};
+  auto offloader = CreateMappedOffloader(layers, kPageBytes);
+  at::Tensor valid = ObjectView(5, 2, 2, kPageBytes);
+  std::memset(valid.data_ptr(), 0x5a, valid.nbytes());
+  at::Tensor invalid =
+      at::zeros({2, 2, static_cast<int64_t>(kPageBytes)}, at::kFloat);
+
+  auto copy = offloader->H2d({0, 1}, {valid, invalid}, /*rank_id=*/0);
+  ASSERT_FALSE(copy.ok());
+  EXPECT_EQ(copy.status().code(), absl::StatusCode::kInvalidArgument);
+
+  std::vector<int8_t> expected_zero(kPageBytes, 0);
+  ExpectLayerBytes(buffers_[0].get(), /*offset=*/0, expected_zero.data(),
+                   kPageBytes);
+  ExpectLayerBytes(buffers_[1].get(), /*offset=*/0, expected_zero.data(),
+                   kPageBytes);
+  EXPECT_TRUE(offloader->UnmapSharedMemory().ok());
+}
+
+TEST_F(KVCacheOffloaderCopyTest, RejectsBlockRankAndTensorLayoutErrors) {
+  constexpr size_t kPageBytes = 32;
+  std::vector<at::Tensor> layers = {AddLayer(4, 4), AddLayer(4, 4)};
+  auto offloader = CreateMappedOffloader(layers, kPageBytes);
+  at::Tensor object0 = ObjectView(3, 2, 2, kPageBytes);
+  at::Tensor object1 = ObjectView(7, 2, 2, kPageBytes);
+
+  EXPECT_EQ(offloader->H2d({-1}, {object0}, 0).status().code(),
+            absl::StatusCode::kOutOfRange);
+  EXPECT_EQ(offloader->H2d({2}, {object0}, 0).status().code(),
+            absl::StatusCode::kOutOfRange);
+  EXPECT_EQ(offloader->H2d({0}, {object0}, 2).status().code(),
+            absl::StatusCode::kOutOfRange);
+  EXPECT_EQ(offloader->H2d({0, 0}, {object0, object1}, 0).status().code(),
+            absl::StatusCode::kInvalidArgument);
+  EXPECT_EQ(offloader->H2d({0}, {object0.transpose(1, 2)}, 0).status().code(),
+            absl::StatusCode::kInvalidArgument);
+  EXPECT_TRUE(offloader->UnmapSharedMemory().ok());
+}
+
+TEST_F(KVCacheOffloaderCopyTest, RequiresMappingAndUnmapDrainsDroppedFuture) {
+  constexpr size_t kPageBytes = 32;
+  constexpr float kInitialValue = 3.25f;
+  std::vector<at::Tensor> layers = {AddLayer(4, 4, kInitialValue)};
+  auto recorder = std::make_shared<MappingRecorder>();
+  auto platform = RecordingPlatform(recorder);
+  auto offloader =
+      KVCacheOffloaderTestPeer::CreateWithTensors(layers, kPageBytes, platform);
+  at::Tensor destination = ObjectView(9, 1, 1, kPageBytes);
+
+  EXPECT_EQ(offloader->D2h({0}, {destination}, 0).status().code(),
+            absl::StatusCode::kFailedPrecondition);
+  ASSERT_TRUE(offloader->MapSharedMemory(kMappedAddress, kPoolSize).ok());
+
+  std::vector<float> source_values(kPageBytes / sizeof(float), kInitialValue);
+  const auto* source = reinterpret_cast<const int8_t*>(source_values.data());
+  {
+    auto dropped = offloader->D2h({0}, {destination}, 0);
+    ASSERT_TRUE(dropped.ok()) << dropped.status();
+  }
+
+  bool observed_copy_before_dma_unmap = false;
+  platform->dma_unmap = [&](void* address) {
+    EXPECT_EQ(address, kMappedAddress);
+    observed_copy_before_dma_unmap =
+        std::memcmp(destination.data_ptr(), source, kPageBytes) == 0;
+    recorder->calls.push_back("DmaUnmap");
+    return absl::OkStatus();
+  };
+  EXPECT_TRUE(offloader->UnmapSharedMemory().ok());
+  EXPECT_TRUE(observed_copy_before_dma_unmap);
+}
+
+}  // namespace
+}  // namespace tpu_raiden::torch

--- a/tpu_sync/frameworks/torch/tpu_raiden_torch_module.cc
+++ b/tpu_sync/frameworks/torch/tpu_raiden_torch_module.cc
@@ -15,6 +15,7 @@
 #include <cstdint>
 #include <memory>
 #include <optional>
+#include <stdexcept>
 #include <string>
 #include <tuple>
 #include <utility>
@@ -37,6 +38,7 @@
 #include "tpu_sync/core/raiden_future.h"
 #include "tpu_sync/core/raw_transfer_core.h"
 #include "tpu_sync/frameworks/torch/kv_cache_manager.h"
+#include "tpu_sync/frameworks/torch/kv_cache_offloader.h"
 #include "tpu_sync/frameworks/torch/pool_layout_nanobind.h"
 #include "tpu_sync/frameworks/torch/torch_nanobind_utils.h"
 #include "tpu_sync/frameworks/torch/weight_synchronizer.h"
@@ -49,7 +51,49 @@
 namespace nb = nanobind;
 
 using ::tpu_raiden::torch::KVCacheManager;
+using ::tpu_raiden::torch::KVCacheOffloader;
 using ::tpu_raiden::torch::WeightSynchronizer;
+
+namespace {
+
+class OffloaderValueError final : public std::runtime_error {
+ public:
+  using std::runtime_error::runtime_error;
+};
+
+class OffloaderIndexError final : public std::runtime_error {
+ public:
+  using std::runtime_error::runtime_error;
+};
+
+class OffloaderOSError final : public std::runtime_error {
+ public:
+  using std::runtime_error::runtime_error;
+};
+
+void ThrowOffloaderStatus(const absl::Status& status,
+                          absl::string_view operation) {
+  if (status.ok())
+    return;
+  const std::string message =
+      absl::StrCat(operation, " failed: ", status.message());
+  if (status
+          .GetPayload(
+              tpu_raiden::torch::offloader_internal::kPosixErrorPayloadUrl)
+          .has_value()) {
+    throw OffloaderOSError(message);
+  }
+  switch (status.code()) {
+    case absl::StatusCode::kInvalidArgument:
+      throw OffloaderValueError(message);
+    case absl::StatusCode::kOutOfRange:
+      throw OffloaderIndexError(message);
+    default:
+      throw std::runtime_error(message);
+  }
+}
+
+}  // namespace
 
 namespace tpu_raiden {
 namespace kv_cache {
@@ -181,6 +225,13 @@ struct ClientHandle {
 using ::tpu_raiden::kv_cache::ToStdStringVector;
 
 NB_MODULE(_tpu_raiden_torch, m) {
+  nb::exception<OffloaderValueError>(m, "_KVCacheOffloaderValueError",
+                                     PyExc_ValueError);
+  nb::exception<OffloaderIndexError>(m, "_KVCacheOffloaderIndexError",
+                                     PyExc_IndexError);
+  nb::exception<OffloaderOSError>(m, "_KVCacheOffloaderOSError",
+                                  PyExc_OSError);
+
   // =========================================================================
   // 1. Bind RaidenFuture
   // =========================================================================
@@ -217,6 +268,58 @@ NB_MODULE(_tpu_raiden_torch, m) {
         absl::Status status = self.PollError();
         return status.ok() ? std::string() : std::string(status.message());
       });
+
+  nb::class_<KVCacheOffloader>(m, "KVCacheOffloader")
+      .def(nb::init<const std::vector<at::Tensor>&, size_t>(),
+           nb::arg("kv_cache_tensors"), nb::arg("page_nbytes"),
+           nb::call_guard<nb::gil_scoped_release>())
+      .def(
+          "map_shared_memory",
+          [](KVCacheOffloader& self, uintptr_t mapped_address,
+             size_t pool_size_bytes) {
+            ThrowOffloaderStatus(
+                self.MapSharedMemory(reinterpret_cast<void*>(mapped_address),
+                                     pool_size_bytes),
+                "KVCacheOffloader.map_shared_memory");
+          },
+          nb::arg("mapped_address"), nb::arg("pool_size_bytes"),
+          nb::call_guard<nb::gil_scoped_release>())
+      .def(
+          "unmap_shared_memory",
+          [](KVCacheOffloader& self) {
+            ThrowOffloaderStatus(self.UnmapSharedMemory(),
+                                 "KVCacheOffloader.unmap_shared_memory");
+          },
+          nb::call_guard<nb::gil_scoped_release>())
+      .def(
+          "h2d",
+          [](KVCacheOffloader& self, const std::vector<int64_t>& block_ids,
+             const std::vector<at::Tensor>& object_tensors, int64_t rank_id) {
+            auto result = self.H2d(block_ids, object_tensors, rank_id);
+            if (!result.ok()) {
+              ThrowOffloaderStatus(result.status(), "KVCacheOffloader.h2d");
+            }
+            return tpu_raiden::RaidenFuture{std::move(result.value())};
+          },
+          nb::arg("block_ids"), nb::arg("object_tensors"), nb::arg("rank_id"),
+          nb::call_guard<nb::gil_scoped_release>())
+      .def(
+          "d2h",
+          [](KVCacheOffloader& self, const std::vector<int64_t>& block_ids,
+             const std::vector<at::Tensor>& object_tensors, int64_t rank_id) {
+            auto result = self.D2h(block_ids, object_tensors, rank_id);
+            if (!result.ok()) {
+              ThrowOffloaderStatus(result.status(), "KVCacheOffloader.d2h");
+            }
+            return tpu_raiden::RaidenFuture{std::move(result.value())};
+          },
+          nb::arg("block_ids"), nb::arg("object_tensors"), nb::arg("rank_id"),
+          nb::call_guard<nb::gil_scoped_release>())
+      .def_prop_ro("num_layers", &KVCacheOffloader::num_layers)
+      .def_prop_ro("num_blocks", &KVCacheOffloader::num_blocks)
+      .def_prop_ro("page_nbytes", &KVCacheOffloader::page_nbytes)
+      .def_prop_ro("is_shared_memory_mapped",
+                   &KVCacheOffloader::is_shared_memory_mapped);
 
   // =========================================================================
   // 2. Bind KVCacheManager


### PR DESCRIPTION
## Summary

- Add a PyTorch `KVCacheOffloader` for bidirectional KV-cache page transfers.
- Register one caller-owned, page-locked host-memory pool through `TpuClient::DmaMap`, then reuse that registration for H2D and D2H transfers from smaller object-tensor views within the pool.
- Keep host-pool allocation and object-view construction outside tpu-sync, while retaining tensors and device buffers until asynchronous transfers complete.
- Serialize map/unmap transitions, reject duplicate lifecycle operations, drain in-flight copies before `DmaUnmap`, and surface the API through the native Torch extension and Python wrapper.
- Require `libtpu>=0.0.47`, which provides the DmaMap behavior used by this path.

## Design

The caller owns the host-memory pool, its page locking, its process-local mapping lifetime, and the construction of mutually disjoint object-tensor views. `map_shared_memory(address, size)` registers the whole pool once with the same PJRT client that owns the KV-cache device buffers. Subsequent `h2d` and `d2h` calls operate on complete object-tensor views and issue raw page transfers without registering each object separately.

`unmap_shared_memory()` first prevents new submissions, waits for all previously submitted copies, and then releases the pool registration through `TpuClient::DmaUnmap`.

## Validation

- `bazel test //tpu_sync/frameworks/torch:kv_cache_offloader_test`
- `python -m unittest -v tpu_sync.api.torch.kv_cache_offloader_test`
- TPU v7x functional DMA round trip on all 8 ranks with topology `2,2,1,2`: H2D, clear host buffers, D2H, byte comparison, and unmap all completed successfully.

