### PR TITLE
Bound the control handshake so a late pull cannot wedge a rank

### DIFF
--- a/tpu_sync/core/BUILD
+++ b/tpu_sync/core/BUILD
@@ -787,6 +787,26 @@ cc_test(
 )
 
 cc_test(
+    name = "kv_cache_manager_with_transfer_control_test",
+    size = "small",
+    srcs = ["kv_cache_manager_with_transfer_control_test.cc"],
+    copts = [
+        "-fno-strict-aliasing",
+        "-fexceptions",
+    ],
+    features = [
+        "-use_header_modules",
+        "-layering_check",
+    ],
+    deps = [
+        ":kv_cache_manager_with_transfer",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/time",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
     name = "kv_cache_manager_perf_test",
     timeout = "long",
     srcs = ["kv_cache_manager_perf_test.cc"],

--- a/tpu_sync/core/kv_cache_manager_with_transfer.cc
+++ b/tpu_sync/core/kv_cache_manager_with_transfer.cc
@@ -23,6 +23,7 @@
 #include <stdio.h>
 #include <sys/poll.h>
 #include <sys/socket.h>
+#include <sys/time.h>
 #include <unistd.h>
 
 #include <algorithm>
@@ -101,6 +102,12 @@ bool EncodeIp(const std::string& ip_str, uint8_t* dst) {
 
 constexpr absl::Duration kPendingWorkTimeout = absl::Seconds(30);
 
+// How long a pull request waits for the producer to register the read it
+// names. The registration normally precedes the announcement the consumer
+// acts on, so this only covers reordering between the two; a pull whose
+// registration expired, or never happened, is rejected once it lapses.
+constexpr absl::Duration kPullRegistrationGrace = absl::Seconds(5);
+
 [[noreturn]] void ThrowStatus(const std::string& context,
                               const absl::Status& status) {
   throw std::runtime_error(context + ": " + std::string(status.message()));
@@ -158,6 +165,9 @@ absl::Status WriteExact(int fd, const void* buffer, size_t length) {
     ssize_t written = write(fd, ptr, remaining);
     if (written < 0) {
       if (errno == EINTR) continue;
+      if (errno == EAGAIN || errno == EWOULDBLOCK) {
+        return absl::DeadlineExceededError("socket write timed out");
+      }
       return absl::InternalError("socket write failed: " +
                                  std::string(std::strerror(errno)));
     }
@@ -177,6 +187,9 @@ absl::Status ReadExact(int fd, void* buffer, size_t length) {
     ssize_t bytes_read = read(fd, ptr, remaining);
     if (bytes_read < 0) {
       if (errno == EINTR) continue;
+      if (errno == EAGAIN || errno == EWOULDBLOCK) {
+        return absl::DeadlineExceededError("socket read timed out");
+      }
       return absl::InternalError("socket read failed: " +
                                  std::string(std::strerror(errno)));
     }
@@ -215,7 +228,23 @@ std::pair<std::string, int> SplitEndpoint(const std::string& endpoint) {
   return {host, port};
 }
 
-int ConnectTcp(const std::string& endpoint) {
+// Bounds every blocking call on `fd`: reads, writes, and for a socket that
+// is not yet connected, the connect itself. A non-positive timeout leaves
+// the socket blocking.
+absl::Status SetSocketTimeouts(int fd, double timeout_s) {
+  if (timeout_s <= 0) return absl::OkStatus();
+  timeval tv;
+  tv.tv_sec = static_cast<time_t>(timeout_s);
+  tv.tv_usec = static_cast<suseconds_t>((timeout_s - tv.tv_sec) * 1e6);
+  if (setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv)) < 0 ||
+      setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv)) < 0) {
+    return absl::InternalError("setsockopt(SO_RCVTIMEO/SO_SNDTIMEO) failed: " +
+                               std::string(std::strerror(errno)));
+  }
+  return absl::OkStatus();
+}
+
+int ConnectTcp(const std::string& endpoint, double timeout_s) {
   auto [host, port] = SplitEndpoint(endpoint);
   struct addrinfo hints;
   struct addrinfo* res = nullptr;
@@ -238,6 +267,11 @@ int ConnectTcp(const std::string& endpoint) {
   }
   int opt = 1;
   setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &opt, sizeof(opt));
+  if (absl::Status status = SetSocketTimeouts(fd, timeout_s); !status.ok()) {
+    close(fd);
+    freeaddrinfo(res);
+    throw std::runtime_error(std::string(status.message()));
+  }
 
   if (connect(fd, res->ai_addr, res->ai_addrlen) < 0) {
     std::string err_str = std::strerror(errno);
@@ -1854,7 +1888,7 @@ void KVCacheManagerWithTransfer::StartRead(
       LOG(INFO) << "StartRead (connecting): req_id=" << req_id
                 << ", uuid=" << uuid
                 << ", numa=" << assigned_numa_node().value_or(-1);
-      int control_fd = ConnectTcp(remote_endpoint);
+      int control_fd = ConnectTcp(remote_endpoint, timeout_s_);
       auto control_cleanup =
           std::unique_ptr<int, void (*)(int*)>(&control_fd, [](int* p) {
             if (p && *p >= 0) close(*p);
@@ -2414,6 +2448,10 @@ void KVCacheManagerWithTransfer::ControlServerLoop() {
       if (errno == EINTR) continue;
       break;
     }
+    if (absl::Status status = SetSocketTimeouts(client_fd, timeout_s_);
+        !status.ok()) {
+      LOG(WARNING) << "control connection: " << status.message();
+    }
     std::optional<int> source_node = assigned_numa_node();
 
     pull_pool_->Schedule(source_node, [this, client_fd]() {
@@ -2454,29 +2492,37 @@ void KVCacheManagerWithTransfer::HandleControlConnection(int fd) {
 
 void KVCacheManagerWithTransfer::ProcessPullStream(
     int fd, const ControlRequestHeader& req) {
+  // The whole request is read before anything can reject it, so a
+  // rejection leaves no unread bytes behind on the connection.
+  std::vector<int64_t> src_block_ids = ReadBlockIds(fd, req.num_blocks);
+  std::vector<int64_t> dst_block_ids = ReadBlockIds(fd, req.num_blocks);
+
   std::shared_ptr<SendEntry> entry;
+  const absl::Duration grace =
+      std::min(kPullRegistrationGrace, absl::Seconds(timeout_s_));
   {
     absl::MutexLock lock(mu_);
+    const absl::Time give_up = absl::Now() + grace;
     while (true) {
       auto it = send_entries_.find(req.uuid);
       if (it != send_entries_.end()) {
         entry = it->second;
         break;
       }
-      if (stopping_.load()) {
+      const absl::Duration left = give_up - absl::Now();
+      if (stopping_.load() || left <= absl::ZeroDuration()) {
         break;
       }
-      cv_.Wait(&mu_);
+      cv_.WaitWithTimeout(&mu_, left);
     }
   }
   if (stopping_) return;
   if (!entry) {
-    throw std::runtime_error(
-        "KVCacheManagerWithTransfer is stopping during wait for send entry");
+    throw std::runtime_error(absl::StrCat(
+        "no read registered for uuid ", req.uuid, " within ",
+        absl::FormatDuration(grace),
+        ": the producer expired it or never registered it"));
   }
-
-  std::vector<int64_t> src_block_ids = ReadBlockIds(fd, req.num_blocks);
-  std::vector<int64_t> dst_block_ids = ReadBlockIds(fd, req.num_blocks);
   ValidateRequestedBlocks(*entry, src_block_ids);
 
   // Acknowledge acceptance to consumer immediately
@@ -2847,7 +2893,7 @@ std::string KVCacheManagerWithTransfer::EndpointWithPort(
 
 void KVCacheManagerWithTransfer::AckRemote(const std::string& remote_endpoint,
                                            uint64_t uuid) {
-  int control_fd = ConnectTcp(remote_endpoint);
+  int control_fd = ConnectTcp(remote_endpoint, timeout_s_);
   auto control_cleanup =
       std::unique_ptr<int, void (*)(int*)>(&control_fd, [](int* p) {
         if (p && *p >= 0) close(*p);

--- a/tpu_sync/core/kv_cache_manager_with_transfer_control_test.cc
+++ b/tpu_sync/core/kv_cache_manager_with_transfer_control_test.cc
@@ -1,0 +1,275 @@
+// Copyright 2026 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Control-plane handshake between a consumer's StartRead and a producer's
+// pull handler, exercised over loopback without a device.
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <cstring>
+#include <optional>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include "absl/strings/str_cat.h"
+#include "absl/time/clock.h"
+#include "absl/time/time.h"
+#include "tpu_sync/core/kv_cache_manager_with_transfer.h"
+
+namespace tpu_raiden {
+namespace {
+
+using ::testing::Contains;
+using ::testing::HasSubstr;
+
+// Both ends of a control handshake share one pool of four workers, so four
+// stuck handshakes are enough to starve either side.
+constexpr int kPoolSize = 4;
+constexpr double kTimeoutS = 0.5;
+
+class TestManager : public KVCacheManagerWithTransfer {
+ public:
+  TestManager()
+      : KVCacheManagerWithTransfer(
+            /*num_layers=*/0, /*num_shards=*/1, /*slice_byte_size=*/128,
+            /*local_port=*/std::nullopt,
+            /*host_blocks_to_allocate=*/std::nullopt,
+            /*parallelism=*/1, /*node_id=*/0,
+            /*local_control_port=*/0, /*max_blocks=*/1,
+            /*num_slots=*/2 * kPoolSize, kTimeoutS) {}
+
+  using KVCacheManagerWithTransfer::ControlRequestHeader;
+  using KVCacheManagerWithTransfer::ControlResponseHeader;
+  using KVCacheManagerWithTransfer::kControlMagic;
+  using KVCacheManagerWithTransfer::kOpPullStream;
+  using KVCacheManagerWithTransfer::kResponseMagic;
+};
+
+int Connect(int port) {
+  int fd = socket(AF_INET, SOCK_STREAM, 0);
+  EXPECT_GE(fd, 0);
+  // A client that would otherwise wait forever fails the test instead.
+  timeval tv{.tv_sec = 10, .tv_usec = 0};
+  setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+  sockaddr_in addr{};
+  addr.sin_family = AF_INET;
+  addr.sin_port = htons(port);
+  addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+  EXPECT_EQ(connect(fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)), 0)
+      << std::strerror(errno);
+  return fd;
+}
+
+void WriteAll(int fd, const void* data, size_t len) {
+  const uint8_t* p = static_cast<const uint8_t*>(data);
+  while (len > 0) {
+    ssize_t n = write(fd, p, len);
+    ASSERT_GT(n, 0) << std::strerror(errno);
+    p += n;
+    len -= n;
+  }
+}
+
+// Returns false when the peer closed or timed out before `len` bytes came.
+bool ReadAll(int fd, void* data, size_t len) {
+  uint8_t* p = static_cast<uint8_t*>(data);
+  while (len > 0) {
+    ssize_t n = read(fd, p, len);
+    if (n <= 0) return false;
+    p += n;
+    len -= n;
+  }
+  return true;
+}
+
+// Sends a one-block pull for `uuid` the way StartRead does.
+void SendPull(int fd, uint64_t uuid) {
+  TestManager::ControlRequestHeader req;
+  req.magic = TestManager::kControlMagic;
+  req.op = TestManager::kOpPullStream;
+  req.uuid = uuid;
+  req.num_blocks = 1;
+  WriteAll(fd, &req, sizeof(req));
+  int64_t block = 0;
+  WriteAll(fd, &block, sizeof(block));  // producer block ids
+  WriteAll(fd, &block, sizeof(block));  // consumer host block ids
+}
+
+struct Response {
+  bool received = false;
+  int32_t status = 0;
+  std::string message;
+};
+
+Response ReadResponse(int fd) {
+  Response out;
+  TestManager::ControlResponseHeader hdr;
+  if (!ReadAll(fd, &hdr, sizeof(hdr))) return out;
+  EXPECT_EQ(hdr.magic, TestManager::kResponseMagic);
+  out.received = true;
+  out.status = hdr.status;
+  out.message.resize(hdr.message_len);
+  if (hdr.message_len > 0) {
+    EXPECT_TRUE(ReadAll(fd, out.message.data(), out.message.size()));
+  }
+  return out;
+}
+
+double SecondsSince(absl::Time start) {
+  return absl::ToDoubleSeconds(absl::Now() - start);
+}
+
+TEST(ControlHandshakeTest, PullWithoutRegistrationIsRejected) {
+  TestManager producer;
+  int fd = Connect(producer.local_control_port());
+  const absl::Time start = absl::Now();
+  SendPull(fd, /*uuid=*/41);
+  Response response = ReadResponse(fd);
+  close(fd);
+
+  ASSERT_TRUE(response.received);
+  EXPECT_NE(response.status, 0);
+  EXPECT_THAT(response.message, HasSubstr("no read registered for uuid 41"));
+  // Rejected once the registration grace lapses, not at some later deadline.
+  EXPECT_LT(SecondsSince(start), 5.0);
+}
+
+TEST(ControlHandshakeTest, PullAheadOfRegistrationIsServedOnceRegistered) {
+  TestManager producer;
+  int fd = Connect(producer.local_control_port());
+  SendPull(fd, /*uuid=*/42);
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  producer.NotifyForRead("req42", 42, /*block_ids=*/{0});
+  Response response = ReadResponse(fd);
+  close(fd);
+
+  ASSERT_TRUE(response.received);
+  EXPECT_EQ(response.status, 0);
+}
+
+TEST(ControlHandshakeTest, HandlersOutliveConsumersThatNeverSpeak) {
+  TestManager producer;
+  // Every handler is held by a consumer that connected and went silent.
+  std::vector<int> idle;
+  for (int i = 0; i < kPoolSize; ++i) {
+    idle.push_back(Connect(producer.local_control_port()));
+  }
+  int fd = Connect(producer.local_control_port());
+  const absl::Time start = absl::Now();
+  SendPull(fd, /*uuid=*/43);
+  Response response = ReadResponse(fd);
+  close(fd);
+  for (int idle_fd : idle) close(idle_fd);
+
+  // The idle connections are dropped at the transfer timeout and the
+  // handlers pick this pull up; it is then rejected within the grace.
+  ASSERT_TRUE(response.received);
+  EXPECT_NE(response.status, 0);
+  EXPECT_LT(SecondsSince(start), 2 * kTimeoutS + 5.0);
+}
+
+// A producer that accepts control connections and never answers them.
+class SilentProducer {
+ public:
+  SilentProducer() {
+    fd_ = socket(AF_INET, SOCK_STREAM, 0);
+    sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    addr.sin_port = 0;
+    EXPECT_EQ(bind(fd_, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)), 0);
+    socklen_t len = sizeof(addr);
+    EXPECT_EQ(getsockname(fd_, reinterpret_cast<sockaddr*>(&addr), &len), 0);
+    port_ = ntohs(addr.sin_port);
+    EXPECT_EQ(listen(fd_, 64), 0);
+    thread_ = std::thread([this] {
+      while (true) {
+        int client = accept(fd_, nullptr, nullptr);
+        if (client < 0) return;
+        ++accepted_;
+        clients_.push_back(client);
+      }
+    });
+  }
+
+  ~SilentProducer() {
+    shutdown(fd_, SHUT_RDWR);
+    close(fd_);
+    thread_.join();
+    for (int client : clients_) close(client);
+  }
+
+  std::string endpoint() const { return absl::StrCat("127.0.0.1:", port_); }
+  int accepted() const { return accepted_.load(); }
+
+ private:
+  int fd_ = -1;
+  int port_ = 0;
+  std::atomic<int> accepted_{0};
+  std::vector<int> clients_;
+  std::thread thread_;
+};
+
+TEST(ControlHandshakeTest, ConsumerGivesUpOnProducerThatNeverAnswers) {
+  SilentProducer producer;
+  TestManager consumer;
+  const absl::Time start = absl::Now();
+  // One more read than the consumer has handshake workers.
+  const int reads = kPoolSize + 1;
+  for (int i = 0; i < reads; ++i) {
+    consumer.StartRead(absl::StrCat("req", i), /*uuid=*/100 + i,
+                       producer.endpoint(), /*remote_block_ids=*/{0},
+                       /*local_block_ids=*/{0});
+  }
+
+  // The last read connects only after a worker gives up on its silent
+  // producer, which happens at the transfer timeout rather than never.
+  while (producer.accepted() < reads && SecondsSince(start) < 10.0) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+  }
+  EXPECT_EQ(producer.accepted(), reads);
+  EXPECT_LT(SecondsSince(start), 2 * kTimeoutS + 5.0);
+
+  // Every read settles rather than leaking its receive entry. With no
+  // layers to receive, the completion sweep can also count an abandoned
+  // read as done, so either report settles it here.
+  std::vector<std::string> settled;
+  while (settled.size() < static_cast<size_t>(reads) &&
+         SecondsSince(start) < 20.0) {
+    auto [done_sending, done_recving, failed_recving] =
+        consumer.CompleteReadRaw();
+    settled.insert(settled.end(), done_recving.begin(), done_recving.end());
+    settled.insert(settled.end(), failed_recving.begin(),
+                   failed_recving.end());
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+  }
+  for (int i = 0; i < reads; ++i) {
+    EXPECT_THAT(settled, Contains(absl::StrCat("req", i)));
+  }
+}
+
+}  // namespace
+}  // namespace tpu_raiden


### PR DESCRIPTION
When a decode rank wants KV pages from a prefill rank, it opens a short exchange: "send me the pages you said were ready for request N." The prefill keeps that offer open only for `timeout_s` (120 s by default). A request that arrives after the offer has expired is a **late pull**. Before this change a late pull froze both sides: the prefill thread that answers such requests waited forever for an offer that was never coming back, and the decode thread that sent the request waited forever for an answer, because its socket had no timeout. Each side has only four of these threads, so four late pulls were enough to stop a rank from answering anyone, while health checks still reported it healthy. This is how a 20-replica production tier stopped serving after a multi-hour eval.

Both ends of the exchange now have a deadline:

- **Prefill:** the answering thread reads the whole request, waits at most 5 seconds (or `timeout_s` if that is shorter) for the offer to appear, then refuses the request with a logged reason instead of waiting.
- **Decode, and every other connection used for these exchanges:** sockets get a send and receive timeout of `timeout_s`, which also bounds the initial connect. A request that runs into it fails with `DeadlineExceeded` instead of hanging.
- **Test:** a new loopback test with four cases that runs without a TPU. It passes with this change; on the old code two cases get no answer within 10 seconds, and the case where the prefill never answers at all hangs until the test's own timeout.

Validated on a one-prefill, one-decode Qwen3-1.7B TPU pair set up to produce late pulls on purpose: offers expiring after 5 seconds, the decode limited to one transfer in flight per rank, and a burst of 64 requests, so that 200 requests reached the prefill after their offers had expired. The unchanged build froze: 0 of 10 requests sent after the burst were answered, and 0 of 16 sent later. With this change alone, all 200 late pulls were refused, and 10 of 10 and 16 of 16 were answered. With sglang-torchtpu#648 on the decode side as well, no late pull reaches the prefill at all.
