### PR TITLE
Reject stale Raiden pulls immediately

### DIFF
--- a/tpu_sync/core/BUILD
+++ b/tpu_sync/core/BUILD
@@ -787,6 +787,24 @@ cc_test(
 )
 
 cc_test(
+    name = "kv_cache_manager_with_transfer_control_test",
+    srcs = ["kv_cache_manager_with_transfer_control_test.cc"],
+    copts = [
+        "-fno-strict-aliasing",
+        "-fexceptions",
+    ],
+    features = [
+        "-use_header_modules",
+        "-layering_check",
+    ],
+    deps = [
+        ":kv_cache_manager_with_transfer",
+        "@com_google_absl//absl/time",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
     name = "kv_cache_manager_perf_test",
     timeout = "long",
     srcs = ["kv_cache_manager_perf_test.cc"],

--- a/tpu_sync/core/kv_cache_manager_with_transfer.cc
+++ b/tpu_sync/core/kv_cache_manager_with_transfer.cc
@@ -674,7 +674,6 @@ int64_t KVCacheManagerWithTransfer::NotifyForRead(
     absl::MutexLock lock(mu_);
     send_entries_[uuid] = entry;
   }
-  cv_.SignalAll();
 
   std::ostringstream timing;
   timing << "RAIDEN_TIMING event=producer_register"
@@ -2372,10 +2371,6 @@ void KVCacheManagerWithTransfer::StopControlServer() {
       RemoveStagingReadinessLocked(staging_readiness_.begin()->first);
     }
   }
-  // Wake workers parked in ProcessPullStream waiting for a send entry that
-  // will never arrive, so their loops observe stopping_ and the pools can
-  // join them.
-  cv_.SignalAll();
   if (control_fd_ >= 0) {
     shutdown(control_fd_, SHUT_RDWR);
     close(control_fd_);
@@ -2445,22 +2440,14 @@ void KVCacheManagerWithTransfer::ProcessPullStream(
   std::shared_ptr<SendEntry> entry;
   {
     absl::MutexLock lock(mu_);
-    while (true) {
-      auto it = send_entries_.find(req.uuid);
-      if (it != send_entries_.end()) {
-        entry = it->second;
-        break;
-      }
-      if (stopping_.load()) {
-        break;
-      }
-      cv_.Wait(&mu_);
+    auto it = send_entries_.find(req.uuid);
+    // The producer registers before publishing the UUID, so an unknown pull
+    // cannot become valid later.
+    if (it == send_entries_.end()) {
+      throw std::runtime_error(
+          absl::StrCat("no send registration for UUID ", req.uuid));
     }
-  }
-  if (stopping_) return;
-  if (!entry) {
-    throw std::runtime_error(
-        "KVCacheManagerWithTransfer is stopping during wait for send entry");
+    entry = it->second;
   }
 
   std::vector<int64_t> src_block_ids = ReadBlockIds(fd, req.num_blocks);

--- a/tpu_sync/core/kv_cache_manager_with_transfer.h
+++ b/tpu_sync/core/kv_cache_manager_with_transfer.h
@@ -531,7 +531,6 @@ class KVCacheManagerWithTransfer : public kv_cache::KVCacheManagerBase {
   std::map<int64_t, std::shared_ptr<StagingReadinessState>>
       active_producer_blocks_;
   absl::Mutex mu_;
-  absl::CondVar cv_;
   int control_fd_ = -1;
   std::atomic<bool> stopping_{false};
   std::thread control_thread_;

--- a/tpu_sync/core/kv_cache_manager_with_transfer_control_test.cc
+++ b/tpu_sync/core/kv_cache_manager_with_transfer_control_test.cc
@@ -1,0 +1,184 @@
+// Copyright 2026 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <arpa/inet.h>
+#include <gtest/gtest.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <unistd.h>
+
+#include <cerrno>
+#include <cstddef>
+#include <cstdint>
+#include <future>
+#include <optional>
+#include <string>
+#include <tuple>
+#include <vector>
+
+#include "absl/time/clock.h"
+#include "absl/time/time.h"
+#include "tpu_sync/core/kv_cache_manager_with_transfer.h"
+
+namespace tpu_raiden {
+namespace {
+
+class TestManager : public KVCacheManagerWithTransfer {
+ public:
+  explicit TestManager(double timeout_s)
+      : KVCacheManagerWithTransfer(
+            /*num_layers=*/1, /*num_shards=*/1,
+            /*slice_byte_size=*/128,
+            /*local_port=*/std::nullopt,
+            /*host_blocks_to_allocate=*/std::make_optional(4),
+            /*parallelism=*/1, /*node_id=*/0,
+            /*local_control_port=*/0, /*max_blocks=*/1, /*num_slots=*/1,
+            timeout_s) {}
+
+  using KVCacheManagerWithTransfer::ControlRequestHeader;
+  using KVCacheManagerWithTransfer::ControlResponseHeader;
+  using KVCacheManagerWithTransfer::kOpPullStream;
+  using KVCacheManagerWithTransfer::kResponseMagic;
+};
+
+class ScopedFd {
+ public:
+  explicit ScopedFd(int fd) : fd_(fd) {}
+  ~ScopedFd() {
+    if (fd_ >= 0) close(fd_);
+  }
+
+  ScopedFd(const ScopedFd&) = delete;
+  ScopedFd& operator=(const ScopedFd&) = delete;
+
+  int get() const { return fd_; }
+
+ private:
+  int fd_;
+};
+
+bool WriteExact(int fd, const void* buffer, size_t length) {
+  const auto* next = static_cast<const uint8_t*>(buffer);
+  while (length > 0) {
+    const ssize_t written = send(fd, next, length, MSG_NOSIGNAL);
+    if (written < 0) {
+      if (errno == EINTR) continue;
+      return false;
+    }
+    if (written == 0) return false;
+    next += written;
+    length -= static_cast<size_t>(written);
+  }
+  return true;
+}
+
+enum class PullResult {
+  kRejected,
+  kAccepted,
+  kTimedOut,
+  kIoError,
+};
+
+PullResult PullMissingSendEntry(int port, uint64_t uuid) {
+  ScopedFd fd(socket(AF_INET6, SOCK_STREAM, 0));
+  if (fd.get() < 0) return PullResult::kIoError;
+
+  timeval timeout = {};
+  timeout.tv_usec = 500000;
+  if (setsockopt(fd.get(), SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout)) <
+      0) {
+    return PullResult::kIoError;
+  }
+
+  sockaddr_in6 address = {};
+  address.sin6_family = AF_INET6;
+  address.sin6_addr = in6addr_loopback;
+  address.sin6_port = htons(port);
+  if (connect(fd.get(), reinterpret_cast<sockaddr*>(&address),
+              sizeof(address)) < 0) {
+    return PullResult::kIoError;
+  }
+
+  TestManager::ControlRequestHeader request;
+  request.op = TestManager::kOpPullStream;
+  request.uuid = uuid;
+  request.num_blocks = 1;
+  const int64_t block_id = 0;
+  if (!WriteExact(fd.get(), &request, sizeof(request)) ||
+      !WriteExact(fd.get(), &block_id, sizeof(block_id)) ||
+      !WriteExact(fd.get(), &block_id, sizeof(block_id))) {
+    return PullResult::kIoError;
+  }
+
+  TestManager::ControlResponseHeader response;
+  ssize_t bytes_read;
+  do {
+    bytes_read = recv(fd.get(), &response, sizeof(response), MSG_WAITALL);
+  } while (bytes_read < 0 && errno == EINTR);
+  if (bytes_read < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
+    return PullResult::kTimedOut;
+  }
+  // The producer rejects before consuming the block-id body. Depending on TCP
+  // timing, its close can surface as either an error response or a reset.
+  if (bytes_read == 0 || (bytes_read < 0 && errno == ECONNRESET)) {
+    return PullResult::kRejected;
+  }
+  if (bytes_read != static_cast<ssize_t>(sizeof(response)) ||
+      response.magic != TestManager::kResponseMagic) {
+    return PullResult::kIoError;
+  }
+  return response.status == 0 ? PullResult::kAccepted : PullResult::kRejected;
+}
+
+TEST(KVCacheManagerWithTransferControlTest, UnknownPullIsRejectedImmediately) {
+  TestManager manager(/*timeout_s=*/120.0);
+  EXPECT_EQ(PullMissingSendEntry(manager.local_control_port(), 99),
+            PullResult::kRejected);
+}
+
+TEST(KVCacheManagerWithTransferControlTest,
+     ExpiredPullsDoNotExhaustControlWorkers) {
+  constexpr uint64_t kFirstUuid = 100;
+  constexpr size_t kStalePullCount = 8;
+  TestManager manager(/*timeout_s=*/0.05);
+  for (uint64_t uuid = kFirstUuid; uuid < kFirstUuid + kStalePullCount;
+       ++uuid) {
+    ASSERT_GT(manager.NotifyForRead(std::to_string(uuid), uuid, {0}), 0);
+  }
+
+  absl::SleepFor(absl::Milliseconds(100));
+  const auto completed = manager.CompleteReadRaw();
+  ASSERT_TRUE(std::get<0>(completed).empty());
+  ASSERT_EQ(std::get<2>(completed).size(), kStalePullCount);
+
+  std::vector<std::future<PullResult>> pulls;
+  pulls.reserve(kStalePullCount);
+  for (uint64_t uuid = kFirstUuid; uuid < kFirstUuid + kStalePullCount;
+       ++uuid) {
+    pulls.push_back(std::async(std::launch::async, [&manager, uuid] {
+      return PullMissingSendEntry(manager.local_control_port(), uuid);
+    }));
+  }
+  for (auto& pull : pulls) {
+    EXPECT_EQ(pull.get(), PullResult::kRejected);
+  }
+
+  EXPECT_EQ(PullMissingSendEntry(manager.local_control_port(),
+                                 kFirstUuid + kStalePullCount),
+            PullResult::kRejected);
+}
+
+}  // namespace
+}  // namespace tpu_raiden


### PR DESCRIPTION
 ## Summary

  Raiden’s producer control handler currently waits indefinitely when a pull references a missing send registration.

  This can wedge a P/D deployment:

  1. A producer registers KV pages with a 120-second deadline.
  2. The decoder queues transfers while its staging slots are occupied.
  3. The producer expires and removes a registration before the queued pull starts.
  4. The late pull reaches the producer, which waits forever for that UUID to reappear.
  5. Four late pulls consume the producer’s four control workers. New TCP connections are accepted but never processed.
  6. Decoder workers wait indefinitely for responses, eventually preventing communication with otherwise healthy producers.
  7. Engine health checks remain green, allowing routing to continue and spread the failure.

  Reject missing registrations immediately instead of waiting. A valid pull cannot race registration because the producer registers the UUID before publishing its CHUNK or BLOCKS announcement. The decoder receives an explicit transfer failure and can abort or recompute without
  consuming a producer worker indefinitely.

  The now-unused condition variable and notification paths are removed.

  ## Test plan

  - Added a CPU-only test using real IPv6 loopback TCP and complete pull frames, including source and destination block-ID arrays.
  - Verified against unmodified main:
      - unknown pull timed out after approximately 500 ms;
      - eight expired pulls exhausted all four control workers;
      - a ninth pull also timed out;
      - both regression tests failed as expected.

  - Verified with the fix:
      - both regression tests passed in approximately 110 ms;
      - all 32 existing kv_cache_manager_with_transfer_pool_reshard_test tests passed.

  - Repeated the new control test 50 times: 50/50 passed.

  bazel test --config=oss -c opt \
    //tpu_sync/core:kv_cache_manager_with_transfer_control_test \
    //tpu_sync/core:kv_cache_manager_with_transfer_pool_reshard_test

  bazel test --config=oss -c opt --runs_per_test=50 \
    //tpu_sync/core:kv_cache_manager_with_transfer_control_test