### PR TITLE
Fix ReshardStore to accept the native RaidenId binding.

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -67,6 +67,7 @@ if [ "$RUN_TORCH" = true ]; then
   python "${WORKSPACE_DIR}/tpu_sync/api/torch/kv_cache_manager_host_test.py"
   python "${WORKSPACE_DIR}/tpu_sync/api/torch/kv_cache_manager_test.py"
   python "${WORKSPACE_DIR}/tpu_sync/api/torch/kv_cache_store_test.py"
+  python "${WORKSPACE_DIR}/tpu_sync/api/torch/reshard_store_test.py"
   python "${WORKSPACE_DIR}/tpu_sync/api/torch/kv_cache_manager_transfer_test.py"
   python "${WORKSPACE_DIR}/tpu_sync/api/torch/weight_synchronizer_test.py"
   python "${WORKSPACE_DIR}/tpu_sync/api/torch/kv_cache_manager_mpmd_test.py"

--- a/tpu_sync/api/torch/BUILD
+++ b/tpu_sync/api/torch/BUILD
@@ -145,6 +145,17 @@ py_test(
 )
 
 py_test(
+    name = "reshard_store_test",
+    srcs = ["reshard_store_test.py"],
+    tags = ["nobuilder"],
+    deps = [
+        ":kv_cache_store",
+        ":reshard_store",
+        "@com_google_absl_py//absl/testing:absltest",
+    ],
+)
+
+py_test(
     name = "weight_synchronizer_test",
     srcs = ["weight_synchronizer_test.py"],
     tags = [

--- a/tpu_sync/api/torch/reshard_store.py
+++ b/tpu_sync/api/torch/reshard_store.py
@@ -49,7 +49,7 @@ class ReshardStore:
     # nb::class_ registration of the same wrapper type would be silently
     # dropped by nanobind.
     self._impl = _impl.create_reshard_store(
-        raiden_id._impl,
+        getattr(raiden_id, "_impl", raiden_id),
         store_server_ip,
         raiden_controller_port,
         reshard_service_port,

--- a/tpu_sync/api/torch/reshard_store_test.py
+++ b/tpu_sync/api/torch/reshard_store_test.py
@@ -1,0 +1,68 @@
+# Copyright 2026 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests that ReshardStore accepts the native RaidenId binding."""
+
+from types import SimpleNamespace
+from unittest import mock
+
+from absl.testing import absltest
+
+from tpu_sync.api.torch import kv_cache_store
+from tpu_sync.api.torch import reshard_store
+
+
+class ReshardStoreTest(absltest.TestCase):
+
+  def test_accepts_native_raiden_id(self):
+    # kv_cache_store.RaidenId is the nanobind class itself, not a Python
+    # wrapper, so it carries no `_impl` attribute to unwrap.
+    native_id = kv_cache_store.RaidenId(
+        job_name="test",
+        job_replica_id="engine",
+        data_name="reshard_store",
+        data_replica_idx=0,
+    )
+    self.assertFalse(hasattr(native_id, "_impl"))
+
+    with mock.patch.object(
+        reshard_store._impl, "create_reshard_store"  # pylint: disable=protected-access
+    ) as factory:
+      store = reshard_store.ReshardStore(native_id, "127.0.0.1", 1234, 1235)
+
+    factory.assert_called_once_with(native_id, "127.0.0.1", 1234, 1235)
+    self.assertIs(store._impl, factory.return_value)  # pylint: disable=protected-access
+
+  def test_unwraps_python_wrapper_with_impl(self):
+    native_id = kv_cache_store.RaidenId(job_name="test", data_name="store")
+    wrapper = SimpleNamespace(_impl=native_id)
+
+    with mock.patch.object(
+        reshard_store._impl, "create_reshard_store"  # pylint: disable=protected-access
+    ) as factory:
+      reshard_store.ReshardStore(wrapper, "127.0.0.1")
+
+    factory.assert_called_once_with(native_id, "127.0.0.1", 0, 0)
+
+  def test_constructs_real_store_on_localhost(self):
+    store = reshard_store.ReshardStore(
+        kv_cache_store.RaidenId(job_name="runtime-test", data_name="store"),
+        "127.0.0.1",
+    )
+    self.assertStartsWith(store.raiden_controller_address, "127.0.0.1:")
+    self.assertGreater(store.reshard_service_port, 0)
+
+
+if __name__ == "__main__":
+  absltest.main()


### PR DESCRIPTION
## Summary

`tpu_sync.api.torch.reshard_store.ReshardStore.__init__` could not be called at
all: it unwrapped its `raiden_id` argument with `raiden_id._impl`, but
`kv_cache_store.RaidenId` has not had an `_impl` attribute since Aug 27. Every
construction raised `AttributeError`.

This change unwraps with `getattr(raiden_id, "_impl", raiden_id)`, matching the
guard the other call sites in `kv_cache_store.py` already use, and adds the
first test for the class.

## Root cause

`kv_cache_store.RaidenId` is resolved as

```python
RaidenId = getattr(_impl, "RaidenId", common.RaidenId)
```

i.e. the nanobind class exported by `_tpu_raiden_torch` when present, else the
pure-Python dataclass in `tpu_sync/api/common.py`. Neither carries `_impl`.

Timeline:

- `4b2b466` (Aug 12) added `reshard_store.py` with `raiden_id._impl`. At that
  time `kv_cache_store.RaidenId` was a Python wrapper class holding the C++
  object in `_impl`, so the line was correct.
- `7efa546` (Aug 27, "fix RaidenId binding") deleted that wrapper and set
  `RaidenId = _impl.RaidenId`. It updated the unwrap sites in
  `kv_cache_store.py` with `hasattr(x, "_impl")` guards but did not touch
  `reshard_store.py`. From here on the constructor raises.
- `a0f5ea1` (Aug 30) changed the alias to the current `getattr(...)` form with
  the dataclass fallback. Still no `_impl` on either branch.

Nothing tested `ReshardStore`, so the breakage went unnoticed.

## Fix

`tpu_sync/api/torch/reshard_store.py`: one-line change from `raiden_id._impl`
to `getattr(raiden_id, "_impl", raiden_id)`. Native ids pass through; a Python
wrapper that does carry `_impl` is still unwrapped.

## Tests

New `tpu_sync/api/torch/reshard_store_test.py` (absltest, registered as a
`py_test` in `tpu_sync/api/torch/BUILD` and added to `run_tests.sh`):

- `test_accepts_native_raiden_id`: asserts the native `RaidenId` has no `_impl`
  (the premise), mocks `create_reshard_store`, and checks the native id is
  forwarded verbatim. Fails on the old code with `AttributeError`.
- `test_unwraps_python_wrapper_with_impl`: an object exposing `_impl` is
  unwrapped before reaching the factory.
- `test_constructs_real_store_on_localhost`: builds a real in-engine store on
  `127.0.0.1` and checks the controller address and reshard service port.

## Testing performed

Before the fix, the old expression on a native id:

```
RaidenId class: <class 'tpu_sync.frameworks.torch._tpu_raiden_torch.RaidenId'>
hasattr _impl: False
AttributeError - 'tpu_sync.frameworks.torch._tpu_raiden_torch.RaidenId' object has no attribute '_impl'
```

After the fix:

```
$ PYTHONPATH=$PWD python -u tpu_sync/api/torch/reshard_store_test.py
[       OK ] ReshardStoreTest.test_accepts_native_raiden_id
[       OK ] ReshardStoreTest.test_constructs_real_store_on_localhost
[       OK ] ReshardStoreTest.test_unwraps_python_wrapper_with_impl
Ran 3 tests in 0.332s
OK
```

## Notes
- Python-only change; no rebuild of the extension is required.
