### PR TITLE
Keep a send's staging until its copies and pushes have ended

### DIFF
--- a/tpu_sync/core/BUILD
+++ b/tpu_sync/core/BUILD
@@ -830,6 +830,31 @@ cc_test(
 )
 
 cc_test(
+    name = "kv_cache_manager_with_transfer_send_drain_test",
+    size = "small",
+    srcs = ["kv_cache_manager_with_transfer_send_drain_test.cc"],
+    copts = [
+        "-fno-strict-aliasing",
+        "-fexceptions",
+    ],
+    features = [
+        "-use_header_modules",
+        "-layering_check",
+    ],
+    deps = [
+        ":kv_cache_manager_with_transfer",
+        ":raw_transfer_core",
+        "@com_google_absl//absl/log:check",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/synchronization",
+        "@com_google_absl//absl/time",
+        "@com_google_googletest//:gtest_main",
+        "@xla//xla:future",
+    ],
+)
+
+cc_test(
     name = "kv_cache_manager_perf_test",
     timeout = "long",
     srcs = ["kv_cache_manager_perf_test.cc"],

--- a/tpu_sync/core/kv_cache_manager_with_transfer.cc
+++ b/tpu_sync/core/kv_cache_manager_with_transfer.cc
@@ -1979,16 +1979,17 @@ KVCacheManagerWithTransfer::CompleteReadRaw() {
     absl::MutexLock lock(mu_);
     const auto now = std::chrono::steady_clock::now();
     for (auto it = send_entries_.begin(); it != send_entries_.end();) {
-      const auto& entry = it->second;
-      if (entry->deadline <= now) {
-        // Nothing pulled this entry within its deadline; the bytes were
-        // never sent, so the transfer failed.
-        failed_recving_.insert(entry->req_id);
-        ReleaseEntrySlotLocked(entry);
-        settled_plans.emplace_back(it->first, 0);
-        it = send_entries_.erase(it);
-      } else {
-        ++it;
+      const std::shared_ptr<SendEntry> entry = it->second;
+      const uint64_t uuid = it->first;
+      ++it;  // retiring the send erases its node
+      if (entry->draining || entry->deadline > now) continue;
+      // Past its deadline the transfer failed. One nobody pulled is
+      // reported now; one whose copies or pushes still run keeps its
+      // staging until they end, so the next transfer is never seated on
+      // memory a copy still writes.
+      FinishSendLocked(entry, /*failed=*/true);
+      if (send_entries_.find(uuid) == send_entries_.end()) {
+        settled_plans.emplace_back(uuid, 0);
       }
     }
     for (auto it = active_pool_reshard_sends_.begin();
@@ -2688,9 +2689,7 @@ bool KVCacheManagerWithTransfer::AcquireSendStagingWithRetry(
                    << (dynamic_host_staging_ ? "the host staging pool holds "
                                              : "a staging slot holds ")
                    << capacity;
-        failed_recving_.insert(it->second->req_id);
-        ReleaseEntrySlotLocked(it->second);
-        send_entries_.erase(it);
+        FinishSendLocked(it->second, /*failed=*/true);
         return false;
       }
       RecvEntry staging;
@@ -2718,9 +2717,7 @@ bool KVCacheManagerWithTransfer::AcquireSendStagingWithRetry(
                    << host_block_manager_->total_blocks()
                    << ", free_slots=" << free_slots_.size()
                    << "); reporting transfer failure";
-        failed_recving_.insert(it->second->req_id);
-        ReleaseEntrySlotLocked(it->second);
-        send_entries_.erase(it);
+        FinishSendLocked(it->second, /*failed=*/true);
       }
       return false;
     }
@@ -2766,8 +2763,17 @@ void KVCacheManagerWithTransfer::StartPushInternal(
   CopySpec d2h_copy = BuildCoalescedCopySpec(src_block_ids, host_block_ids);
   entry->d2h_layer_futures.reserve(num_layers());
 
-  // 1. Issue D2H copies layer-by-layer!
+  // 1. Issue D2H copies layer-by-layer. Each copy is counted against the
+  // send before it starts and released by its own completion, so the
+  // staging it writes stays owned for as long as it runs.
   for (size_t l = 0; l < num_layers(); ++l) {
+    {
+      absl::MutexLock lock(mu_);
+      // The send expired or failed while its copies were being issued:
+      // what was issued drains, nothing more starts.
+      if (entry->draining) return;
+      BeginSendOpLocked(entry);
+    }
     LOG(INFO) << "StartPushInternal (D2H start) layer " << l
               << ": uuid=" << uuid
               << ", numa=" << assigned_numa_node().value_or(-1);
@@ -2780,15 +2786,15 @@ void KVCacheManagerWithTransfer::StartPushInternal(
       LOG(ERROR) << "StartPushInternal: failed to issue D2H for layer " << l
                  << ": " << future_or.status();
       absl::MutexLock lock(mu_);
-      auto it = send_entries_.find(uuid);
-      if (it != send_entries_.end()) {
-        failed_recving_.insert(it->second->req_id);
-        ReleaseEntrySlotLocked(it->second);
-        send_entries_.erase(it);
-      }
+      FinishSendLocked(entry, /*failed=*/true);
+      EndSendOpLocked(entry);  // this copy never started
       return;
     }
     entry->d2h_layer_futures.push_back(std::move(future_or.value()));
+    entry->d2h_layer_futures.back().OnReady(
+        [this, entry](absl::StatusOr<raiden::BufferHolders>) {
+          EndSendOp(entry);
+        });
   }
 
   entry->remote_data_endpoints = remote_data_endpoints;
@@ -2796,78 +2802,49 @@ void KVCacheManagerWithTransfer::StartPushInternal(
   entry->dst_ints.assign(dst_block_ids.begin(), dst_block_ids.end());
   entry->remaining_h2h_layers.store(num_layers());
 
-  SendNextLayer(uuid, 0);
+  SendNextLayer(entry, 0);
 }
 
-void KVCacheManagerWithTransfer::SendNextLayer(uint64_t uuid, size_t l) {
-  RAIDEN_TRACE_FN("KVTransfer::SendNextLayer",
-                  [&]() { return absl::StrCat("uuid=", uuid, " layer=", l); });
-  std::shared_ptr<SendEntry> entry;
-  {
-    absl::MutexLock lock(mu_);
-    auto it = send_entries_.find(uuid);
-    if (it == send_entries_.end()) {
-      return;
-    }
-    entry = it->second;
-  }
-
+void KVCacheManagerWithTransfer::SendNextLayer(
+    const std::shared_ptr<SendEntry>& entry, size_t l) {
+  RAIDEN_TRACE_FN("KVTransfer::SendNextLayer", [&]() {
+    return absl::StrCat("uuid=", entry->uuid, " layer=", l);
+  });
   if (l >= num_layers()) {
     // Reached end of layer loop. Background asynchronous transfers will clean
     // up when remaining_h2h_layers reaches 0.
     return;
   }
+  const uint64_t uuid = entry->uuid;
 
-  entry->d2h_layer_futures[l].OnReady([this, uuid, l](auto status_or) {
+  entry->d2h_layer_futures[l].OnReady([this, entry, uuid, l](auto status_or) {
     if (!status_or.ok()) {
       LOG(ERROR) << "StartPushInternal: D2H copy failed for layer " << l
                  << ", status: " << status_or.status().ToString();
       absl::MutexLock lock(mu_);
-      auto it = send_entries_.find(uuid);
-      if (it != send_entries_.end()) {
-        failed_recving_.insert(it->second->req_id);
-        ReleaseEntrySlotLocked(it->second);
-        send_entries_.erase(it);
-      }
+      FinishSendLocked(entry, /*failed=*/true);
       return;
     }
+    {
+      absl::MutexLock lock(mu_);
+      // The send expired or failed while the copy ran: nothing is pushed.
+      if (entry->draining) return;
+      BeginSendOpLocked(entry);
+    }
 
-    push_pool_->Schedule([this, uuid, l]() {
-      std::shared_ptr<SendEntry> entry;
-      {
-        absl::MutexLock lock(mu_);
-        auto it = send_entries_.find(uuid);
-        if (it == send_entries_.end()) {
-          return;
-        }
-        entry = it->second;
-      }
+    push_pool_->Schedule([this, entry, uuid, l]() {
       LOG(INFO) << "StartPushInternal (H2H start layer " << l
                 << "): uuid=" << uuid
                 << ", numa=" << assigned_numa_node().value_or(-1);
       H2hWriteDirectAsync(
           entry->remote_data_endpoints, entry->src_ints, entry->dst_ints, uuid,
-          l, [this, uuid, l](absl::StatusOr<std::vector<int>> push_res) {
-            std::shared_ptr<SendEntry> entry;
-            {
-              absl::MutexLock lock(mu_);
-              auto it = send_entries_.find(uuid);
-              if (it != send_entries_.end()) {
-                entry = it->second;
-              }
-            }
-            if (!entry) return;
-
+          l, [this, entry, uuid, l](absl::StatusOr<std::vector<int>> push_res) {
             if (!push_res.ok()) {
               LOG(ERROR) << "H2hWrite failed for layer " << l << ": "
                          << push_res.status().ToString();
               absl::MutexLock lock(mu_);
-              if (auto it = send_entries_.find(uuid);
-                  it != send_entries_.end()) {
-                failed_recving_.insert(entry->req_id);
-                ReleaseEntrySlotLocked(entry);
-                send_entries_.erase(it);
-              }
+              FinishSendLocked(entry, /*failed=*/true);
+              EndSendOpLocked(entry);
               return;
             }
 
@@ -2875,24 +2852,56 @@ void KVCacheManagerWithTransfer::SendNextLayer(uint64_t uuid, size_t l) {
                       << "): uuid=" << uuid
                       << ", numa=" << assigned_numa_node().value_or(-1);
 
-            if (entry->remaining_h2h_layers.fetch_sub(1) == 1) {
+            const bool last = entry->remaining_h2h_layers.fetch_sub(1) == 1;
+            absl::MutexLock lock(mu_);
+            if (last) {
               LOG(INFO) << "StartPushInternal (All H2H complete): uuid="
                         << uuid;
-              absl::MutexLock lock(mu_);
-              if (auto it = send_entries_.find(uuid);
-                  it != send_entries_.end()) {
-                done_sending_.insert(entry->req_id);
-                ReleaseEntrySlotLocked(entry);
-                send_entries_.erase(it);
-              }
+              FinishSendLocked(entry, /*failed=*/false);
             }
+            EndSendOpLocked(entry);
           });
 
       // Immediately queue the next layer's push without waiting for this one to
       // finish
-      SendNextLayer(uuid, l + 1);
+      SendNextLayer(entry, l + 1);
     });
   });
+}
+
+void KVCacheManagerWithTransfer::FinishSendLocked(
+    const std::shared_ptr<SendEntry>& entry, bool failed) {
+  if (failed) entry->failed = true;
+  if (entry->draining) return;  // the pending work retires it
+  entry->draining = true;
+  if (entry->in_flight == 0) RetireSendLocked(entry);
+}
+
+void KVCacheManagerWithTransfer::RetireSendLocked(
+    const std::shared_ptr<SendEntry>& entry) {
+  (entry->failed ? failed_recving_ : done_sending_).insert(entry->req_id);
+  ReleaseEntrySlotLocked(entry);
+  auto it = send_entries_.find(entry->uuid);
+  if (it != send_entries_.end() && it->second == entry) {
+    send_entries_.erase(it);
+  }
+}
+
+void KVCacheManagerWithTransfer::BeginSendOpLocked(
+    const std::shared_ptr<SendEntry>& entry) {
+  ++entry->in_flight;
+}
+
+void KVCacheManagerWithTransfer::EndSendOpLocked(
+    const std::shared_ptr<SendEntry>& entry) {
+  --entry->in_flight;
+  if (entry->draining && entry->in_flight == 0) RetireSendLocked(entry);
+}
+
+void KVCacheManagerWithTransfer::EndSendOp(
+    const std::shared_ptr<SendEntry>& entry) {
+  absl::MutexLock lock(mu_);
+  EndSendOpLocked(entry);
 }
 
 absl::Status KVCacheManagerWithTransfer::WaitForPendingWork() {
@@ -2986,9 +2995,7 @@ void KVCacheManagerWithTransfer::AckSend(uint64_t uuid) {
       return;
     }
     entry = it->second;
-    done_sending_.insert(entry->req_id);
-    ReleaseEntrySlotLocked(entry);
-    send_entries_.erase(it);
+    FinishSendLocked(entry, /*failed=*/false);
   }
   const auto ack_done = std::chrono::steady_clock::now();
   std::ostringstream timing;

--- a/tpu_sync/core/kv_cache_manager_with_transfer.h
+++ b/tpu_sync/core/kv_cache_manager_with_transfer.h
@@ -289,6 +289,13 @@ class KVCacheManagerWithTransfer : public kv_cache::KVCacheManagerBase {
     bool failed = false;
     bool pull_started = false;
     bool slot_released = false;
+    // Copies and pushes issued for this send whose completion has not been
+    // observed. The staging they read and write is held until it is zero.
+    // Guarded by mu_.
+    int in_flight = 0;
+    // The outcome is decided (failed, or every push done) and the send
+    // waits for its in-flight work before it is reported. Guarded by mu_.
+    bool draining = false;
     std::chrono::steady_clock::time_point deadline;
     std::vector<raiden::PjRtCopyFuture> d2h_layer_futures;
     std::vector<std::string> remote_data_endpoints;
@@ -480,7 +487,19 @@ class KVCacheManagerWithTransfer : public kv_cache::KVCacheManagerBase {
                          const std::vector<std::string>& remote_data_endpoints,
                          const std::vector<int64_t>& src_block_ids,
                          const std::vector<int64_t>& dst_block_ids);
-  void SendNextLayer(uint64_t uuid, size_t l);
+  void SendNextLayer(const std::shared_ptr<SendEntry>& entry, size_t l);
+  // Decides a pull-serve send's outcome. The send is reported and its
+  // staging returned once nothing issued for it is still running: at once
+  // for a send nobody pulled, otherwise when its last copy or push ends.
+  // A failure outranks a completion decided later.
+  void FinishSendLocked(const std::shared_ptr<SendEntry>& entry, bool failed);
+  // Reports the send's outcome, returns its staging and drops the entry.
+  void RetireSendLocked(const std::shared_ptr<SendEntry>& entry);
+  // Counts one copy or push issued for the send.
+  void BeginSendOpLocked(const std::shared_ptr<SendEntry>& entry);
+  // Counts one finished copy or push; retires a send that waited for it.
+  void EndSendOpLocked(const std::shared_ptr<SendEntry>& entry);
+  void EndSendOp(const std::shared_ptr<SendEntry>& entry);
 
   absl::Status ValidatePoolReshardPlan(
       const ::tpu_sync::rpc::StartTransferRequest& plan,

--- a/tpu_sync/core/kv_cache_manager_with_transfer_send_drain_test.cc
+++ b/tpu_sync/core/kv_cache_manager_with_transfer_send_drain_test.cc
@@ -1,0 +1,172 @@
+// Copyright 2026 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// A pull-serve send that expires or fails while its device-to-host copies
+// are still running, exercised without a device: the copies complete when
+// the test says so.
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include "absl/log/check.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/synchronization/mutex.h"
+#include "absl/time/clock.h"
+#include "absl/time/time.h"
+#include "xla/future.h"
+#include "tpu_sync/core/kv_cache_manager_with_transfer.h"
+#include "tpu_sync/core/raw_transfer_core.h"
+
+namespace tpu_raiden {
+namespace {
+
+using ::testing::Contains;
+using ::testing::IsEmpty;
+
+constexpr int64_t kSlots = 2;
+constexpr double kTimeoutS = 0.05;
+
+// A producer whose device-to-host copies complete when the test says so.
+class TestManager : public KVCacheManagerWithTransfer {
+ public:
+  explicit TestManager(size_t num_layers)
+      : KVCacheManagerWithTransfer(num_layers, /*num_shards=*/1,
+                                   /*slice_byte_size=*/128,
+                                   /*local_port=*/std::nullopt,
+                                   /*host_blocks_to_allocate=*/std::nullopt,
+                                   /*parallelism=*/1, /*node_id=*/0,
+                                   /*local_control_port=*/-1, /*max_blocks=*/1,
+                                   /*num_slots=*/kSlots, kTimeoutS) {
+    CHECK_OK(ConfigureHostStagingSlots(kSlots, /*max_major_per_slot=*/1));
+    CHECK_OK(InitializeSlotPool(kSlots));
+  }
+
+  // Serves a pull for `uuid` the way ProcessPullStream does once the
+  // consumer is acknowledged: the push runs on this thread and returns
+  // with its copies issued.
+  void ServePull(uint64_t uuid) {
+    {
+      absl::MutexLock lock(mu_);
+      send_entries_.at(uuid)->pull_started = true;
+    }
+    StartPushInternal(uuid, {"127.0.0.1:1"}, /*src_block_ids=*/{0},
+                      /*dst_block_ids=*/{0});
+  }
+
+  size_t copies_issued() {
+    absl::MutexLock lock(copies_mu_);
+    return copies_.size();
+  }
+
+  // Completes the `index`-th copy issued.
+  void FinishCopy(size_t index, absl::Status status) {
+    absl::MutexLock lock(copies_mu_);
+    copies_.at(index).Set(std::move(status));
+  }
+
+  size_t free_slots() {
+    absl::MutexLock lock(mu_);
+    return free_slots_.size();
+  }
+
+  absl::StatusOr<raiden::PjRtCopyFuture> D2hSyncDispatch(
+      const std::vector<int64_t>& src_offsets_major_dim,
+      const std::vector<int64_t>& dst_offsets_major_dim,
+      const std::vector<int64_t>& copy_sizes_major_dim,
+      std::optional<int64_t> slot_idx, std::optional<size_t> layer_idx,
+      std::optional<size_t> shard_idx) override {
+    auto [promise, future] = xla::MakePromise<>();
+    absl::MutexLock lock(copies_mu_);
+    copies_.push_back(std::move(promise));
+    return raiden::PjRtCopyFuture(std::move(future), raiden::BufferHolders{});
+  }
+
+ private:
+  absl::Mutex copies_mu_;
+  std::vector<xla::Promise<>> copies_;
+};
+
+using Reports = std::tuple<std::vector<std::string>, std::vector<std::string>,
+                           std::vector<std::string>>;
+
+const std::vector<std::string>& DoneSending(const Reports& r) {
+  return std::get<0>(r);
+}
+const std::vector<std::string>& FailedRecving(const Reports& r) {
+  return std::get<2>(r);
+}
+
+TEST(SendDrainTest, ExpiredSendKeepsItsStagingUntilTheCopyEnds) {
+  TestManager producer(/*num_layers=*/1);
+  ASSERT_GT(producer.NotifyForRead("req", /*uuid=*/7, {0}), 0);
+  producer.ServePull(7);
+  ASSERT_EQ(producer.copies_issued(), 1);
+  EXPECT_EQ(producer.free_slots(), kSlots - 1);
+
+  // The deadline passes while the copy runs: the send is not reported and
+  // its slot stays out of the pool.
+  absl::SleepFor(absl::Milliseconds(120));
+  Reports during = producer.CompleteReadRaw();
+  EXPECT_THAT(DoneSending(during), IsEmpty());
+  EXPECT_THAT(FailedRecving(during), IsEmpty());
+  EXPECT_EQ(producer.free_slots(), kSlots - 1);
+
+  // The copy lands after the deadline: the send is reported failed, not
+  // done, and only now hands its slot back.
+  producer.FinishCopy(0, absl::OkStatus());
+  Reports after = producer.CompleteReadRaw();
+  EXPECT_THAT(DoneSending(after), IsEmpty());
+  EXPECT_THAT(FailedRecving(after), Contains("req"));
+  EXPECT_EQ(producer.free_slots(), kSlots);
+}
+
+TEST(SendDrainTest, FailedLayerWaitsForTheOtherLayersCopies) {
+  TestManager producer(/*num_layers=*/2);
+  ASSERT_GT(producer.NotifyForRead("req", /*uuid=*/8, {0}), 0);
+  producer.ServePull(8);
+  ASSERT_EQ(producer.copies_issued(), 2);
+
+  // Layer 0's copy fails while layer 1's still runs: the failure and the
+  // slot are held back.
+  producer.FinishCopy(0, absl::InternalError("copy failed"));
+  Reports during = producer.CompleteReadRaw();
+  EXPECT_THAT(FailedRecving(during), IsEmpty());
+  EXPECT_EQ(producer.free_slots(), kSlots - 1);
+
+  producer.FinishCopy(1, absl::OkStatus());
+  Reports after = producer.CompleteReadRaw();
+  EXPECT_THAT(DoneSending(after), IsEmpty());
+  EXPECT_THAT(FailedRecving(after), Contains("req"));
+  EXPECT_EQ(producer.free_slots(), kSlots);
+}
+
+TEST(SendDrainTest, SendNobodyPulledFailsAtItsDeadline) {
+  TestManager producer(/*num_layers=*/1);
+  ASSERT_GT(producer.NotifyForRead("req", /*uuid=*/9, {0}), 0);
+  absl::SleepFor(absl::Milliseconds(120));
+  Reports swept = producer.CompleteReadRaw();
+  EXPECT_THAT(FailedRecving(swept), Contains("req"));
+  EXPECT_EQ(producer.free_slots(), kSlots);
+}
+
+}  // namespace
+}  // namespace tpu_raiden


### PR DESCRIPTION
The producer's deadline sweep and its per-layer failure paths settled a pull-serve send at once: the outcome was reported and the host staging returned while the device-to-host copies and pushes issued for that send were still running. The staging could be handed to the next transfer under a copy still writing it, and the connector, told the send was over, could free source pages a copy still read.

- Each copy and push issued for a send is counted on its entry (`in_flight`); the outcome is reported and the staging returned only when the count reaches zero. A send nobody pulled is unchanged: it fails at its deadline.
- Once a send expired or failed it pushes nothing more; a failure decided earlier outranks a completion decided later. A send whose push never completes stays registered, with its staging, until the transport reports that push.
- New device-less test `kv_cache_manager_with_transfer_send_drain_test` (3 cases): on the unpatched code the expired send and the failed layer are reported, and their slot returned, while a copy still runs; here both wait for the copy.

Validation: OSS build (`--config=oss`, CPU build container): the new test passes 3/3, and `kv_cache_manager_with_transfer_control_test`, `kv_cache_manager_with_transfer_ip_test` and the other device-less `//tpu_sync/core` tests pass; on the unpatched code 2 of the 3 new cases fail. Not yet run on TPU end to end: the raiden wheel the serving stacks pin predates this tree, so that run waits for the pin bump.
