### PR TITLE
Benchmark the PR head commit by SHA in the presubmit workflow

### DIFF
--- a/.github/workflows/presubmit_benchmarks.yml
+++ b/.github/workflows/presubmit_benchmarks.yml
@@ -29,3 +29,8 @@ jobs:
       registry_file: "tpu_sync/benchmarks/benchmark_registry.pbtxt"
       bap_ref: "aa854ba7bdb77966a9cc1a013417f1c1a208c4c0"
       runner: "linux-x86-n2-8"
+      # Benchmark the PR head commit by SHA. The reusable workflow otherwise
+      # checks out the head branch name from this repository, which does not
+      # exist for pull requests opened from forks or after the branch is
+      # deleted at merge time.
+      experiment_ref: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
The presubmit benchmark workflow checks out the pull request head by branch name from this repository. That branch does not exist here for pull requests opened from forks (#906 fails on every run), and it is deleted at merge time for same-repo pull requests, so the last benchmark run of each copybara PR fails as well (#905 is the latest example). Because the h2h_cpp_gate shard is a required status check, a fork PR cannot merge today.

- Passes the PR head SHA as the experiment ref to the reusable benchmark workflow, which already prefers an explicit ref over the branch name.
- The head commit of a pull request is fetchable from this repository by SHA whether it came from a fork or its branch has since been deleted.
- The recorded `branch` field of a benchmark result carries the SHA instead of a branch name.
- No change to the reusable workflow pin or to the benchmark registry.

Validation: fetching the fork PR head c8ae61d8 (#906) and the merged-and-deleted head 6bea0bb2 (#905) from google/tpu-sync by SHA both succeed, while fetching either branch name fails with the same git exit code seen in CI.
