### PR TITLE
Strengthen Raiden protocol lifecycle coverage

### DIFF
--- a/tpu_sync/core/BUILD
+++ b/tpu_sync/core/BUILD
@@ -848,7 +848,6 @@ cc_test(
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/synchronization",
-        "@com_google_absl//absl/time",
         "@com_google_googletest//:gtest_main",
         "@xla//xla:future",
     ],

--- a/tpu_sync/core/kv_cache_manager_with_transfer_control_test.cc
+++ b/tpu_sync/core/kv_cache_manager_with_transfer_control_test.cc
@@ -16,6 +16,8 @@
 // pull handler, exercised over loopback without a device.
 
 #include <arpa/inet.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
 #include <netinet/in.h>
 #include <netinet/tcp.h>
 #include <sys/socket.h>
@@ -26,15 +28,17 @@
 #include <atomic>
 #include <cerrno>
 #include <chrono>
+#include <cstddef>
 #include <cstdint>
 #include <cstring>
+#include <future>
+#include <memory>
 #include <optional>
 #include <string>
 #include <thread>
+#include <type_traits>
 #include <vector>
 
-#include <gmock/gmock.h>
-#include <gtest/gtest.h>
 #include "absl/log/log.h"
 #include "absl/strings/str_cat.h"
 #include "absl/time/clock.h"
@@ -54,14 +58,14 @@ constexpr double kTimeoutS = 0.5;
 
 class TestManager : public KVCacheManagerWithTransfer {
  public:
-  TestManager()
+  explicit TestManager(double timeout_s = kTimeoutS)
       : KVCacheManagerWithTransfer(
             /*num_layers=*/0, /*num_shards=*/1, /*slice_byte_size=*/128,
             /*local_port=*/std::nullopt,
             /*host_blocks_to_allocate=*/std::nullopt,
             /*parallelism=*/1, /*node_id=*/0,
-            /*local_control_port=*/0, /*max_blocks=*/1,
-            /*num_slots=*/2 * kPoolSize, kTimeoutS) {}
+            /*local_control_port=*/0, /*max_blocks=*/8,
+            /*num_slots=*/2 * kPoolSize, timeout_s) {}
 
   using KVCacheManagerWithTransfer::ControlRequestHeader;
   using KVCacheManagerWithTransfer::ControlResponseHeader;
@@ -69,6 +73,19 @@ class TestManager : public KVCacheManagerWithTransfer {
   using KVCacheManagerWithTransfer::kOpPullStream;
   using KVCacheManagerWithTransfer::kResponseMagic;
 };
+
+// These structs are copied directly onto the wire. Keep their ABI explicit so
+// a compiler or field-layout change cannot silently break mixed-version peers.
+static_assert(std::is_standard_layout_v<TestManager::ControlRequestHeader>);
+static_assert(sizeof(TestManager::ControlRequestHeader) == 168);
+static_assert(offsetof(TestManager::ControlRequestHeader, magic) == 0);
+static_assert(offsetof(TestManager::ControlRequestHeader, uuid) == 8);
+static_assert(offsetof(TestManager::ControlRequestHeader, num_blocks) == 24);
+static_assert(offsetof(TestManager::ControlRequestHeader, consumer_ips) == 36);
+static_assert(std::is_standard_layout_v<TestManager::ControlResponseHeader>);
+static_assert(sizeof(TestManager::ControlResponseHeader) == 24);
+static_assert(offsetof(TestManager::ControlResponseHeader, status) == 4);
+static_assert(offsetof(TestManager::ControlResponseHeader, message_len) == 16);
 
 int Connect(int port) {
   int fd = socket(AF_INET, SOCK_STREAM, 0);
@@ -116,17 +133,28 @@ bool ReadAll(int fd, void* data, size_t len) {
   return true;
 }
 
+void SendRequest(int fd, uint32_t magic, uint32_t op, uint64_t uuid,
+                 const std::vector<int64_t>& source_blocks,
+                 const std::vector<int64_t>& destination_blocks) {
+  ASSERT_EQ(source_blocks.size(), destination_blocks.size());
+  TestManager::ControlRequestHeader req;
+  req.magic = magic;
+  req.op = op;
+  req.uuid = uuid;
+  req.num_blocks = source_blocks.size();
+  WriteAll(fd, &req, sizeof(req));
+  if (!source_blocks.empty()) {
+    WriteAll(fd, source_blocks.data(),
+             source_blocks.size() * sizeof(source_blocks[0]));
+    WriteAll(fd, destination_blocks.data(),
+             destination_blocks.size() * sizeof(destination_blocks[0]));
+  }
+}
+
 // Sends a one-block pull for `uuid` the way StartRead does.
 void SendPull(int fd, uint64_t uuid) {
-  TestManager::ControlRequestHeader req;
-  req.magic = TestManager::kControlMagic;
-  req.op = TestManager::kOpPullStream;
-  req.uuid = uuid;
-  req.num_blocks = 1;
-  WriteAll(fd, &req, sizeof(req));
-  int64_t block = 0;
-  WriteAll(fd, &block, sizeof(block));  // producer block ids
-  WriteAll(fd, &block, sizeof(block));  // consumer host block ids
+  SendRequest(fd, TestManager::kControlMagic, TestManager::kOpPullStream, uuid,
+              /*source_blocks=*/{0}, /*destination_blocks=*/{0});
 }
 
 struct Response {
@@ -153,6 +181,18 @@ double SecondsSince(absl::Time start) {
   return absl::ToDoubleSeconds(absl::Now() - start);
 }
 
+TEST(ControlHandshakeTest, RegisteredPullIsAcknowledged) {
+  TestManager producer;
+  ASSERT_GT(producer.NotifyForRead("req40", /*uuid=*/40, {0}), 0);
+  int fd = Connect(producer.local_control_port());
+  SendPull(fd, /*uuid=*/40);
+  Response response = ReadResponse(fd);
+  close(fd);
+
+  ASSERT_TRUE(response.received);
+  EXPECT_EQ(response.status, 0);
+}
+
 TEST(ControlHandshakeTest, PullWithoutRegistrationIsRejected) {
   TestManager producer;
   int fd = Connect(producer.local_control_port());
@@ -168,17 +208,109 @@ TEST(ControlHandshakeTest, PullWithoutRegistrationIsRejected) {
   EXPECT_LT(SecondsSince(start), 5.0);
 }
 
-TEST(ControlHandshakeTest, PullAheadOfRegistrationIsServedOnceRegistered) {
+TEST(ControlHandshakeTest,
+     PullAheadOfRegistrationIsAcknowledgedOnceRegistered) {
   TestManager producer;
   int fd = Connect(producer.local_control_port());
   SendPull(fd, /*uuid=*/42);
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
-  producer.NotifyForRead("req42", 42, /*block_ids=*/{0});
+  auto response_future = std::async(std::launch::async, ReadResponse, fd);
+
+  // The pull is observably pending before registration; this avoids assuming
+  // that a fixed sleep was long enough for a particular worker schedule.
+  EXPECT_EQ(response_future.wait_for(std::chrono::milliseconds(100)),
+            std::future_status::timeout);
+  ASSERT_GT(producer.NotifyForRead("req42", 42, /*block_ids=*/{0}), 0);
+  ASSERT_EQ(response_future.wait_for(std::chrono::seconds(1)),
+            std::future_status::ready);
+  Response response = response_future.get();
+  close(fd);
+
+  ASSERT_TRUE(response.received);
+  EXPECT_EQ(response.status, 0);
+}
+
+TEST(ControlHandshakeTest, UniqueRegisteredSubsetIsAcknowledged) {
+  TestManager producer;
+  ASSERT_GT(producer.NotifyForRead("req44", /*uuid=*/44, {0, 1, 2}), 0);
+  int fd = Connect(producer.local_control_port());
+  SendRequest(fd, TestManager::kControlMagic, TestManager::kOpPullStream,
+              /*uuid=*/44, /*source_blocks=*/{2, 0},
+              /*destination_blocks=*/{6, 7});
   Response response = ReadResponse(fd);
   close(fd);
 
   ASSERT_TRUE(response.received);
   EXPECT_EQ(response.status, 0);
+}
+
+TEST(ControlHandshakeTest, PullOfUnregisteredBlockIsRejected) {
+  TestManager producer;
+  ASSERT_GT(producer.NotifyForRead("req45", /*uuid=*/45, {0, 1}), 0);
+  int fd = Connect(producer.local_control_port());
+  SendRequest(fd, TestManager::kControlMagic, TestManager::kOpPullStream,
+              /*uuid=*/45, /*source_blocks=*/{0, 2},
+              /*destination_blocks=*/{6, 7});
+  Response response = ReadResponse(fd);
+  close(fd);
+
+  ASSERT_TRUE(response.received);
+  EXPECT_NE(response.status, 0);
+  EXPECT_THAT(response.message, HasSubstr("block not registered"));
+}
+
+TEST(ControlHandshakeTest, PullWithDuplicateSourceBlockIsRejected) {
+  TestManager producer;
+  ASSERT_GT(producer.NotifyForRead("req46", /*uuid=*/46, {0, 1}), 0);
+  int fd = Connect(producer.local_control_port());
+  SendRequest(fd, TestManager::kControlMagic, TestManager::kOpPullStream,
+              /*uuid=*/46, /*source_blocks=*/{0, 0},
+              /*destination_blocks=*/{6, 7});
+  Response response = ReadResponse(fd);
+  close(fd);
+
+  ASSERT_TRUE(response.received);
+  EXPECT_NE(response.status, 0);
+  EXPECT_THAT(response.message, HasSubstr("duplicate producer block"));
+}
+
+TEST(ControlHandshakeTest, EmptyPullIsRejected) {
+  TestManager producer;
+  ASSERT_GT(producer.NotifyForRead("req47", /*uuid=*/47, {0}), 0);
+  int fd = Connect(producer.local_control_port());
+  SendRequest(fd, TestManager::kControlMagic, TestManager::kOpPullStream,
+              /*uuid=*/47, /*source_blocks=*/{}, /*destination_blocks=*/{});
+  Response response = ReadResponse(fd);
+  close(fd);
+
+  ASSERT_TRUE(response.received);
+  EXPECT_NE(response.status, 0);
+  EXPECT_THAT(response.message, HasSubstr("requested no blocks"));
+}
+
+TEST(ControlHandshakeTest, BadMagicIsRejected) {
+  TestManager producer;
+  int fd = Connect(producer.local_control_port());
+  SendRequest(fd, /*magic=*/0, TestManager::kOpPullStream, /*uuid=*/48,
+              /*source_blocks=*/{}, /*destination_blocks=*/{});
+  Response response = ReadResponse(fd);
+  close(fd);
+
+  ASSERT_TRUE(response.received);
+  EXPECT_NE(response.status, 0);
+  EXPECT_THAT(response.message, HasSubstr("bad control request magic"));
+}
+
+TEST(ControlHandshakeTest, UnknownOperationIsRejected) {
+  TestManager producer;
+  int fd = Connect(producer.local_control_port());
+  SendRequest(fd, TestManager::kControlMagic, /*op=*/99, /*uuid=*/49,
+              /*source_blocks=*/{}, /*destination_blocks=*/{});
+  Response response = ReadResponse(fd);
+  close(fd);
+
+  ASSERT_TRUE(response.received);
+  EXPECT_NE(response.status, 0);
+  EXPECT_THAT(response.message, HasSubstr("unknown control op code"));
 }
 
 TEST(ControlHandshakeTest, HandlersOutliveConsumersThatNeverSpeak) {
@@ -200,6 +332,26 @@ TEST(ControlHandshakeTest, HandlersOutliveConsumersThatNeverSpeak) {
   ASSERT_TRUE(response.received);
   EXPECT_NE(response.status, 0);
   EXPECT_LT(SecondsSince(start), 2 * kTimeoutS + 5.0);
+}
+
+TEST(ControlHandshakeTest, ShutdownUnblocksPendingPull) {
+  auto producer = std::make_unique<TestManager>(/*timeout_s=*/10.0);
+  int fd = Connect(producer->local_control_port());
+  SendPull(fd, /*uuid=*/51);
+  auto response_future = std::async(std::launch::async, ReadResponse, fd);
+
+  // Establish the externally visible precondition: the pull is still pending
+  // and has neither been acknowledged nor rejected before shutdown begins.
+  EXPECT_EQ(response_future.wait_for(std::chrono::milliseconds(100)),
+            std::future_status::timeout);
+
+  const absl::Time start = absl::Now();
+  producer.reset();
+  ASSERT_EQ(response_future.wait_for(std::chrono::seconds(1)),
+            std::future_status::ready);
+  (void)response_future.get();
+  close(fd);
+  EXPECT_LT(SecondsSince(start), 1.0);
 }
 
 // A producer that accepts control connections and never answers them.

--- a/tpu_sync/core/kv_cache_manager_with_transfer_send_drain_test.cc
+++ b/tpu_sync/core/kv_cache_manager_with_transfer_send_drain_test.cc
@@ -16,25 +16,26 @@
 // are still running, exercised without a device: the copies complete when
 // the test says so.
 
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
+#include <memory>
 #include <optional>
 #include <string>
 #include <tuple>
 #include <utility>
 #include <vector>
 
-#include <gmock/gmock.h>
-#include <gtest/gtest.h>
 #include "absl/log/check.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/synchronization/mutex.h"
-#include "absl/time/clock.h"
-#include "absl/time/time.h"
-#include "xla/future.h"
 #include "tpu_sync/core/kv_cache_manager_with_transfer.h"
 #include "tpu_sync/core/raw_transfer_core.h"
+#include "xla/future.h"
 
 namespace tpu_raiden {
 namespace {
@@ -88,7 +89,120 @@ class TestManager : public KVCacheManagerWithTransfer {
     return free_slots_.size();
   }
 
+  void ExpireSend(uint64_t uuid) {
+    absl::MutexLock lock(mu_);
+    send_entries_.at(uuid)->deadline =
+        std::chrono::steady_clock::now() - std::chrono::milliseconds(1);
+  }
+
+  // White-box construction for the send retirement state machine. Tests that
+  // need registration and dispatch use NotifyForRead and ServePull instead.
+  std::shared_ptr<SendEntry> AddSyntheticSend(const std::string& req_id,
+                                              uint64_t uuid, int in_flight) {
+    absl::MutexLock lock(mu_);
+    auto entry = std::make_shared<SendEntry>();
+    entry->req_id = req_id;
+    entry->uuid = uuid;
+    entry->slot_idx = AcquireSlotLocked().slot_idx;
+    entry->in_flight = in_flight;
+    send_entries_[uuid] = entry;
+    return entry;
+  }
+
+  void Decide(const std::shared_ptr<SendEntry>& entry, bool failed) {
+    absl::MutexLock lock(mu_);
+    FinishSendLocked(entry, failed);
+  }
+
+  void End(const std::shared_ptr<SendEntry>& entry) {
+    absl::MutexLock lock(mu_);
+    EndSendOpLocked(entry);
+  }
+
+  bool has_send(uint64_t uuid) {
+    absl::MutexLock lock(mu_);
+    return send_entries_.contains(uuid);
+  }
+
   absl::StatusOr<raiden::PjRtCopyFuture> D2hSyncDispatch(
+      const std::vector<int64_t>& src_offsets_major_dim,
+      const std::vector<int64_t>& dst_offsets_major_dim,
+      const std::vector<int64_t>& copy_sizes_major_dim,
+      std::optional<int64_t> slot_idx, std::optional<size_t> layer_idx,
+      std::optional<size_t> shard_idx) override {
+    auto [promise, future] = xla::MakePromise<>();
+    absl::MutexLock lock(copies_mu_);
+    copies_.push_back(std::move(promise));
+    return raiden::PjRtCopyFuture(std::move(future), raiden::BufferHolders{});
+  }
+
+ private:
+  absl::Mutex copies_mu_;
+  std::vector<xla::Promise<>> copies_;
+};
+
+// A consumer whose host-to-device copies complete when the test says so.
+class RecvTestManager : public KVCacheManagerWithTransfer {
+ public:
+  explicit RecvTestManager(size_t num_layers, double timeout_s = 5.0)
+      : KVCacheManagerWithTransfer(num_layers, /*num_shards=*/1,
+                                   /*slice_byte_size=*/128,
+                                   /*local_port=*/std::nullopt,
+                                   /*host_blocks_to_allocate=*/std::nullopt,
+                                   /*parallelism=*/1, /*node_id=*/0,
+                                   /*local_control_port=*/-1, /*max_blocks=*/1,
+                                   /*num_slots=*/kSlots, timeout_s) {
+    CHECK_OK(ConfigureHostStagingSlots(kSlots, /*max_major_per_slot=*/1));
+    CHECK_OK(InitializeSlotPool(kSlots));
+  }
+
+  void AddRecv(const std::string& req_id, uint64_t uuid,
+               int32_t blocks_per_layer = 1) {
+    absl::MutexLock lock(mu_);
+    RecvEntry entry;
+    entry.req_id = req_id;
+    entry.slot_idx = AcquireSlotLocked().slot_idx;
+    entry.total_blocks = blocks_per_layer;
+    entry.deadline = DeadlineFromNow();
+    entry.start_time = std::chrono::steady_clock::now();
+    active_recv_entries_[uuid] = std::move(entry);
+  }
+
+  absl::Status ReceiveLayer(size_t layer, uint64_t uuid) {
+    return OnLayerReceived(layer, uuid);
+  }
+
+  absl::Status ReceiveBlocks(const std::vector<int>& blocks, uint64_t uuid) {
+    return OnBlocksReceived(blocks, uuid);
+  }
+
+  void FinishCopy(size_t index, absl::Status status) {
+    absl::MutexLock lock(copies_mu_);
+    copies_.at(index).Set(std::move(status));
+  }
+
+  size_t copies_issued() {
+    absl::MutexLock lock(copies_mu_);
+    return copies_.size();
+  }
+
+  size_t free_slots() {
+    absl::MutexLock lock(mu_);
+    return free_slots_.size();
+  }
+
+  bool has_recv(uint64_t uuid) {
+    absl::MutexLock lock(mu_);
+    return active_recv_entries_.contains(uuid);
+  }
+
+  void ExpireRecv(uint64_t uuid) {
+    absl::MutexLock lock(mu_);
+    active_recv_entries_.at(uuid).deadline =
+        std::chrono::steady_clock::now() - std::chrono::milliseconds(1);
+  }
+
+  absl::StatusOr<raiden::PjRtCopyFuture> H2dSyncDispatch(
       const std::vector<int64_t>& src_offsets_major_dim,
       const std::vector<int64_t>& dst_offsets_major_dim,
       const std::vector<int64_t>& copy_sizes_major_dim,
@@ -111,6 +225,9 @@ using Reports = std::tuple<std::vector<std::string>, std::vector<std::string>,
 const std::vector<std::string>& DoneSending(const Reports& r) {
   return std::get<0>(r);
 }
+const std::vector<std::string>& DoneReceiving(const Reports& r) {
+  return std::get<1>(r);
+}
 const std::vector<std::string>& FailedRecving(const Reports& r) {
   return std::get<2>(r);
 }
@@ -124,7 +241,7 @@ TEST(SendDrainTest, ExpiredSendKeepsItsStagingUntilTheCopyEnds) {
 
   // The deadline passes while the copy runs: the send is not reported and
   // its slot stays out of the pool.
-  absl::SleepFor(absl::Milliseconds(120));
+  producer.ExpireSend(/*uuid=*/7);
   Reports during = producer.CompleteReadRaw();
   EXPECT_THAT(DoneSending(during), IsEmpty());
   EXPECT_THAT(FailedRecving(during), IsEmpty());
@@ -162,10 +279,172 @@ TEST(SendDrainTest, FailedLayerWaitsForTheOtherLayersCopies) {
 TEST(SendDrainTest, SendNobodyPulledFailsAtItsDeadline) {
   TestManager producer(/*num_layers=*/1);
   ASSERT_GT(producer.NotifyForRead("req", /*uuid=*/9, {0}), 0);
-  absl::SleepFor(absl::Milliseconds(120));
+  producer.ExpireSend(/*uuid=*/9);
   Reports swept = producer.CompleteReadRaw();
   EXPECT_THAT(FailedRecving(swept), Contains("req"));
   EXPECT_EQ(producer.free_slots(), kSlots);
+}
+
+TEST(SendLifecycleTest, SuccessfulSendWithoutWorkSettlesImmediately) {
+  TestManager producer(/*num_layers=*/1);
+  auto entry = producer.AddSyntheticSend("req", /*uuid=*/10, /*in_flight=*/0);
+
+  producer.Decide(entry, /*failed=*/false);
+  Reports reports = producer.CompleteReadRaw();
+  EXPECT_THAT(DoneSending(reports), Contains("req"));
+  EXPECT_THAT(FailedRecving(reports), IsEmpty());
+  EXPECT_FALSE(producer.has_send(10));
+  EXPECT_EQ(producer.free_slots(), kSlots);
+}
+
+TEST(SendLifecycleTest, FailedSendWithoutWorkSettlesImmediately) {
+  TestManager producer(/*num_layers=*/1);
+  auto entry = producer.AddSyntheticSend("req", /*uuid=*/11, /*in_flight=*/0);
+
+  producer.Decide(entry, /*failed=*/true);
+  Reports reports = producer.CompleteReadRaw();
+  EXPECT_THAT(DoneSending(reports), IsEmpty());
+  EXPECT_THAT(FailedRecving(reports), Contains("req"));
+  EXPECT_FALSE(producer.has_send(11));
+  EXPECT_EQ(producer.free_slots(), kSlots);
+}
+
+TEST(SendLifecycleTest, SuccessfulSendWaitsForEveryOperation) {
+  TestManager producer(/*num_layers=*/1);
+  auto entry = producer.AddSyntheticSend("req", /*uuid=*/12, /*in_flight=*/2);
+
+  producer.Decide(entry, /*failed=*/false);
+  producer.End(entry);
+  Reports during = producer.CompleteReadRaw();
+  EXPECT_THAT(DoneSending(during), IsEmpty());
+  EXPECT_THAT(FailedRecving(during), IsEmpty());
+  EXPECT_TRUE(producer.has_send(12));
+  EXPECT_EQ(producer.free_slots(), kSlots - 1);
+
+  producer.End(entry);
+  Reports after = producer.CompleteReadRaw();
+  EXPECT_THAT(DoneSending(after), Contains("req"));
+  EXPECT_THAT(FailedRecving(after), IsEmpty());
+  EXPECT_FALSE(producer.has_send(12));
+  EXPECT_EQ(producer.free_slots(), kSlots);
+}
+
+TEST(SendLifecycleTest, FailureWinsWhileSuccessfulSendIsDraining) {
+  TestManager producer(/*num_layers=*/1);
+  auto entry = producer.AddSyntheticSend("req", /*uuid=*/13, /*in_flight=*/1);
+
+  producer.Decide(entry, /*failed=*/false);
+  producer.Decide(entry, /*failed=*/true);
+  producer.End(entry);
+  Reports reports = producer.CompleteReadRaw();
+  EXPECT_THAT(DoneSending(reports), IsEmpty());
+  EXPECT_THAT(FailedRecving(reports), Contains("req"));
+  EXPECT_FALSE(producer.has_send(13));
+  EXPECT_EQ(producer.free_slots(), kSlots);
+}
+
+TEST(SendLifecycleTest, SuccessCannotOverrideAnEarlierFailure) {
+  TestManager producer(/*num_layers=*/1);
+  auto entry = producer.AddSyntheticSend("req", /*uuid=*/14, /*in_flight=*/1);
+
+  producer.Decide(entry, /*failed=*/true);
+  producer.Decide(entry, /*failed=*/false);
+  producer.End(entry);
+  Reports reports = producer.CompleteReadRaw();
+  EXPECT_THAT(DoneSending(reports), IsEmpty());
+  EXPECT_THAT(FailedRecving(reports), Contains("req"));
+  EXPECT_FALSE(producer.has_send(14));
+  EXPECT_EQ(producer.free_slots(), kSlots);
+}
+
+TEST(RecvLifecycleTest, NetworkCompletionWaitsForH2d) {
+  RecvTestManager consumer(/*num_layers=*/1);
+  consumer.AddRecv("req", /*uuid=*/20);
+  ASSERT_TRUE(consumer.ReceiveLayer(/*layer=*/0, /*uuid=*/20).ok());
+  ASSERT_EQ(consumer.copies_issued(), 1);
+  ASSERT_TRUE(consumer.ReceiveBlocks({0}, /*uuid=*/20).ok());
+
+  Reports during = consumer.CompleteReadRaw();
+  EXPECT_THAT(DoneReceiving(during), IsEmpty());
+  EXPECT_TRUE(consumer.has_recv(20));
+  EXPECT_EQ(consumer.free_slots(), kSlots - 1);
+
+  consumer.FinishCopy(0, absl::OkStatus());
+  Reports after = consumer.CompleteReadRaw();
+  EXPECT_THAT(DoneReceiving(after), Contains("req"));
+  EXPECT_THAT(FailedRecving(after), IsEmpty());
+  EXPECT_FALSE(consumer.has_recv(20));
+  EXPECT_EQ(consumer.free_slots(), kSlots);
+}
+
+TEST(RecvLifecycleTest, LateBlockAccountingAfterRetirementIsANoOp) {
+  RecvTestManager consumer(/*num_layers=*/1);
+  consumer.AddRecv("req", /*uuid=*/21);
+  ASSERT_TRUE(consumer.ReceiveLayer(/*layer=*/0, /*uuid=*/21).ok());
+  consumer.FinishCopy(0, absl::OkStatus());
+
+  Reports reports = consumer.CompleteReadRaw();
+  EXPECT_THAT(DoneReceiving(reports), Contains("req"));
+  EXPECT_THAT(FailedRecving(reports), IsEmpty());
+  EXPECT_FALSE(consumer.has_recv(21));
+  EXPECT_EQ(consumer.free_slots(), kSlots);
+
+  // BlockTransport calls this immediately after OnLayerReceived. A fast H2D
+  // callback may already have retired the receive, so the late accounting is
+  // deliberately harmless.
+  EXPECT_TRUE(consumer.ReceiveBlocks({0}, /*uuid=*/21).ok());
+  Reports after_late_accounting = consumer.CompleteReadRaw();
+  EXPECT_THAT(DoneSending(after_late_accounting), IsEmpty());
+  EXPECT_THAT(DoneReceiving(after_late_accounting), IsEmpty());
+  EXPECT_THAT(FailedRecving(after_late_accounting), IsEmpty());
+  EXPECT_FALSE(consumer.has_recv(21));
+  EXPECT_EQ(consumer.free_slots(), kSlots);
+}
+
+TEST(RecvLifecycleTest, OutOfOrderLayersSettleAfterEveryH2d) {
+  RecvTestManager consumer(/*num_layers=*/2);
+  consumer.AddRecv("req", /*uuid=*/22);
+
+  ASSERT_TRUE(consumer.ReceiveLayer(/*layer=*/1, /*uuid=*/22).ok());
+  ASSERT_TRUE(consumer.ReceiveBlocks({0}, /*uuid=*/22).ok());
+  consumer.FinishCopy(0, absl::OkStatus());
+  Reports after_one = consumer.CompleteReadRaw();
+  EXPECT_THAT(DoneReceiving(after_one), IsEmpty());
+  EXPECT_TRUE(consumer.has_recv(22));
+
+  ASSERT_TRUE(consumer.ReceiveLayer(/*layer=*/0, /*uuid=*/22).ok());
+  ASSERT_TRUE(consumer.ReceiveBlocks({0}, /*uuid=*/22).ok());
+  consumer.FinishCopy(1, absl::OkStatus());
+  Reports after_both = consumer.CompleteReadRaw();
+  EXPECT_THAT(DoneReceiving(after_both), Contains("req"));
+  EXPECT_THAT(FailedRecving(after_both), IsEmpty());
+  EXPECT_FALSE(consumer.has_recv(22));
+  EXPECT_EQ(consumer.free_slots(), kSlots);
+}
+
+TEST(RecvLifecycleTest, SingleFailedH2dReportsFailureAndReturnsStaging) {
+  RecvTestManager consumer(/*num_layers=*/1);
+  consumer.AddRecv("req", /*uuid=*/23);
+  ASSERT_TRUE(consumer.ReceiveLayer(/*layer=*/0, /*uuid=*/23).ok());
+  consumer.FinishCopy(0, absl::InternalError("copy failed"));
+
+  Reports reports = consumer.CompleteReadRaw();
+  EXPECT_THAT(DoneReceiving(reports), IsEmpty());
+  EXPECT_THAT(FailedRecving(reports), Contains("req"));
+  EXPECT_FALSE(consumer.has_recv(23));
+  EXPECT_EQ(consumer.free_slots(), kSlots);
+}
+
+TEST(RecvLifecycleTest, ReceiveWithoutTrafficFailsAtItsDeadline) {
+  RecvTestManager consumer(/*num_layers=*/1, /*timeout_s=*/kTimeoutS);
+  consumer.AddRecv("req", /*uuid=*/24);
+  consumer.ExpireRecv(/*uuid=*/24);
+
+  Reports reports = consumer.CompleteReadRaw();
+  EXPECT_THAT(DoneReceiving(reports), IsEmpty());
+  EXPECT_THAT(FailedRecving(reports), Contains("req"));
+  EXPECT_FALSE(consumer.has_recv(24));
+  EXPECT_EQ(consumer.free_slots(), kSlots);
 }
 
 }  // namespace


### PR DESCRIPTION
## Summary

  Strengthens Raiden protocol lifecycle coverage without changing production behavior.

  ## Changes

  - Adds coverage for control handshakes, shutdown, send retirement, and receive completion.
  - Replaces timing-dependent expiry sleeps with deterministic state transitions.
  - Strengthens assertions around staging-slot release and late callbacks.
  - Adds compile-time checks for the raw control-message wire layout.
  - Clarifies test names and expected behavior.

  ## Test plan

  Ran both targets 20 times:

  //tpu_sync/core:kv_cache_manager_with_transfer_control_test
  //tpu_sync/core:kv_cache_manager_with_transfer_send_drain_test

  Result: 500/500 test cases passed.